### PR TITLE
Update GitLab documentation to clarify the usage of base-url

### DIFF
--- a/auth/providers/gitlab/options.go
+++ b/auth/providers/gitlab/options.go
@@ -21,7 +21,7 @@ func (o *Options) Configure() error {
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.BaseUrl, "gitlab.base-url", o.BaseUrl, "Base url for enterprise, keep empty to use default gitlab base url")
+	fs.StringVar(&o.BaseUrl, "gitlab.base-url", o.BaseUrl, "Base url for GitLab, including the API path, keep empty to use default gitlab base url. ")
 }
 
 func (o *Options) Validate() []error {

--- a/docs/guides/authenticator/gitlab.md
+++ b/docs/guides/authenticator/gitlab.md
@@ -35,9 +35,12 @@ $ kubectl apply -f installer.yaml
 Additional flags for gitlab:
 
 ```console
-# Base url for enterprise, keep empty to use default gitlab base url
+# Base url for GitLab, keep empty to use default gitlab base url
 --gitlab.base-url=<base_url>
 ```
+
+The GitLab base-url needs to include the path to the API. For example
+`https://<base-url>/api/v4`
 
 ### Issue Token
 


### PR DESCRIPTION
Clarifies the usage of base-url when using the GitLab authentication. 

- The base-url needs to include the path to the API. The current API is v4, and this is included as an example in the documentation. 
- Remove the Enterprise reference for GitLab