### PR TITLE
Use image with tag 0.1.0 not canary

### DIFF
--- a/installer/deployment.go
+++ b/installer/deployment.go
@@ -41,7 +41,7 @@ func newDeployment(opts Options) (objects []runtime.Object, err error) {
 					Containers: []core.Container{
 						{
 							Name:  "guard",
-							Image: fmt.Sprintf("%s/guard:%v", opts.PrivateRegistry, stringz.Val(v.Version.Version, "canary")),
+							Image: fmt.Sprintf("%s/guard:%v", opts.PrivateRegistry, stringz.Val(v.Version.Version, "0.1.0")),
 							Args: []string{
 								"run",
 								"--v=3",


### PR DESCRIPTION
## WHY

After following the installation guide published at https://appscode.com/products/guard/0.1.0/setup/install/, I could not manage to get the container start
### pod status
`guard-5c566f688b-j2mk2 0/1 CrashLoopBackOff 12 37m`
### log of the pod
```
Error: unknown flag: --tls-ca-file
Usage:
  guard run [flags]

Flags:
      --ca-cert-file string   File containing CA certificate
      --cert-file string      File container server TLS certificate
  -h, --help                  help for run
      --key-file string       File containing server TLS private key
      --ops-addr string       Address to listen on for web interface and telemetry. (default ":56790")
      --web-address string    Http server address (default ":9844")

Global Flags:
      --alsologtostderr                  log to standard error as well as files
      --analytics                        Send analytical events to Google Guard (default true)
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files (default true)
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs (default 0)
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
```

I believe this is because I was using an image with the tag `canary`, which has not been updated for 4 months according to https://hub.docker.com/r/appscode/guard/tags/ .
Changing `canary` to `0.1.0` worked for me.

## WHAT

I changed default tag from `canary` to `0.1.0`.

## NOTE

I don't mind closing this PR to fix installation guide or some deploy flow,
because I really don't know this is the cause.
(Maybe `canary` should be updated more often? or maybe I did something wrong)