### PR TITLE
Use absolute path as aliases for reference docs

### DIFF
--- a/docs/reference/guard.md
+++ b/docs/reference/guard.md
@@ -11,7 +11,7 @@ product_name: guard
 menu_name: product_guard_0.4.0
 section_menu_id: reference
 aliases:
-  - products/guard/0.4.0/reference/
+  - /products/guard/0.4.0/reference/
 
 ---
 ## guard

--- a/hack/gendocs/main.go
+++ b/hack/gendocs/main.go
@@ -47,7 +47,7 @@ menu_name: product_guard_{{ .Version }}
 section_menu_id: reference
 {{- if .RootCmd }}
 aliases:
-  - products/guard/{{ .Version }}/reference/
+  - /products/guard/{{ .Version }}/reference/
 {{ end }}
 ---
 `))


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>