### PR TITLE
migrate from apps/v1beta1 to apps/v1

### DIFF
--- a/auth/providers/azure/options.go
+++ b/auth/providers/azure/options.go
@@ -7,7 +7,7 @@ import (
 	"github.com/appscode/go/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-	"k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,7 +50,7 @@ func (o *Options) Validate() []error {
 	return errs
 }
 
-func (o Options) Apply(d *v1beta1.Deployment) (extraObjs []runtime.Object, err error) {
+func (o Options) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err error) {
 	container := d.Spec.Template.Spec.Containers[0]
 
 	// create auth secret

--- a/auth/providers/github/options.go
+++ b/auth/providers/github/options.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
-	"k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -28,7 +28,7 @@ func (o *Options) Validate() []error {
 	return nil
 }
 
-func (o Options) Apply(d *v1beta1.Deployment) (extraObjs []runtime.Object, err error) {
+func (o Options) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err error) {
 	args := d.Spec.Template.Spec.Containers[0].Args
 	if o.BaseUrl != "" {
 		args = append(args, fmt.Sprintf("--github.base-url=%s", o.BaseUrl))

--- a/auth/providers/gitlab/options.go
+++ b/auth/providers/gitlab/options.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
-	"k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -32,7 +32,7 @@ func (o *Options) Validate() []error {
 	return nil
 }
 
-func (o Options) Apply(d *v1beta1.Deployment) (extraObjs []runtime.Object, err error) {
+func (o Options) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err error) {
 	args := d.Spec.Template.Spec.Containers[0].Args
 	if o.BaseUrl != "" {
 		args = append(args, fmt.Sprintf("--gitlab.base-url=%s", o.BaseUrl))

--- a/auth/providers/google/options.go
+++ b/auth/providers/google/options.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 	gdir "google.golang.org/api/admin/directory/v1"
-	"k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -63,7 +63,7 @@ func (o *Options) Validate() []error {
 	return errs
 }
 
-func (o Options) Apply(d *v1beta1.Deployment) (extraObjs []runtime.Object, err error) {
+func (o Options) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err error) {
 	container := d.Spec.Template.Spec.Containers[0]
 
 	// create auth secret

--- a/auth/providers/ldap/options.go
+++ b/auth/providers/ldap/options.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"gopkg.in/jcmturner/gokrb5.v4/keytab"
-	"k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -211,7 +211,7 @@ func (o *Options) Validate() []error {
 	return errs
 }
 
-func (o Options) Apply(d *v1beta1.Deployment) (extraObjs []runtime.Object, err error) {
+func (o Options) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err error) {
 	container := d.Spec.Template.Spec.Containers[0]
 
 	// create auth secret

--- a/auth/providers/providers.go
+++ b/auth/providers/providers.go
@@ -13,7 +13,7 @@ import (
 	_ "github.com/appscode/guard/auth/providers/token"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-	"k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -39,7 +39,7 @@ func (a *AuthProviders) Validate() []error {
 	return errs
 }
 
-func (a *AuthProviders) Apply(d *v1beta1.Deployment) (extraObjs []runtime.Object, err error) {
+func (a *AuthProviders) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err error) {
 	if len(a.Providers) > 0 {
 		d.Spec.Template.Spec.Containers[0].Args = append(d.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--auth-providers=%s", strings.Join(a.Providers, ",")))
 	}

--- a/auth/providers/token/options.go
+++ b/auth/providers/token/options.go
@@ -6,7 +6,7 @@ import (
 	"github.com/appscode/go/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-	"k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +32,7 @@ func (o *Options) Validate() []error {
 	return errs
 }
 
-func (o Options) Apply(d *v1beta1.Deployment) (extraObjs []runtime.Object, err error) {
+func (o Options) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err error) {
 	container := d.Spec.Template.Spec.Containers[0]
 
 	// create auth secret

--- a/docs/examples/installer.yaml
+++ b/docs/examples/installer.yaml
@@ -11,7 +11,7 @@ metadata:
   name: guard-pki
   namespace: kube-system
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -22,6 +22,9 @@ metadata:
 spec:
   replicas: 1
   strategy: {}
+  selector:
+    matchLabels:
+      app: guard
   template:
     metadata:
       creationTimestamp: null

--- a/installer/deployment.go
+++ b/installer/deployment.go
@@ -64,6 +64,16 @@ func newDeployment(opts Options) (objects []runtime.Object, err error) {
 								},
 								InitialDelaySeconds: int32(30),
 							},
+							LivenessProbe: &core.Probe{
+								Handler: core.Handler{
+									HTTPGet: &core.HTTPGetAction{
+										Path:   "/healthz",
+										Port:   intstr.FromInt(server.ServingPort),
+										Scheme: core.URISchemeHTTPS,
+									},
+								},
+								InitialDelaySeconds: int32(30),
+							},
 						},
 					},
 					Tolerations: []core.Toleration{

--- a/installer/deployment.go
+++ b/installer/deployment.go
@@ -13,7 +13,7 @@ import (
 	"github.com/appscode/guard/auth/providers/ldap"
 	"github.com/appscode/guard/auth/providers/token"
 	"github.com/appscode/guard/server"
-	apps "k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,6 +29,9 @@ func newDeployment(opts Options) (objects []runtime.Object, err error) {
 		},
 		Spec: apps.DeploymentSpec{
 			Replicas: types.Int32P(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
 			Template: core.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/server/serving.go
+++ b/server/serving.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
 	"gomodules.xyz/cert/certstore"
-	"k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,7 +71,7 @@ func (o *SecureServingOptions) Validate() []error {
 	return errs
 }
 
-func (o SecureServingOptions) Apply(d *v1beta1.Deployment) (extraObjs []runtime.Object, err error) {
+func (o SecureServingOptions) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err error) {
 	// create auth secret
 	store, err := certstore.NewCertStore(afero.NewOsFs(), filepath.Join(o.pkiDir, "pki"))
 	if err != nil {

--- a/test/e2e/framework/deployment.go
+++ b/test/e2e/framework/deployment.go
@@ -1,14 +1,14 @@
 package framework
 
 import (
-	apps "k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (f *Framework) DeleteDeployment(name, namespace string) error {
-	return f.KubeClient.AppsV1beta1().Deployments(namespace).Delete(name, deleteInBackground())
+	return f.KubeClient.AppsV1().Deployments(namespace).Delete(name, deleteInBackground())
 }
 
 func (f *Framework) GetDeployment(name, namespace string) (*apps.Deployment, error) {
-	return f.KubeClient.AppsV1beta1().Deployments(namespace).Get(name, metav1.GetOptions{})
+	return f.KubeClient.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
 }

--- a/test/e2e/installer_test.go
+++ b/test/e2e/installer_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Installer test", func() {
 		checkDeploymentCreated = func() {
 			By("Checking deployment created. deployment name: " + deploymentName)
 			Eventually(func() bool {
-				if obj, err := f.KubeClient.AppsV1beta1().Deployments(root.Namespace()).Get(deploymentName, metav1.GetOptions{}); err == nil {
+				if obj, err := f.KubeClient.AppsV1().Deployments(root.Namespace()).Get(deploymentName, metav1.GetOptions{}); err == nil {
 					return *obj.Spec.Replicas == obj.Status.ReadyReplicas
 				}
 				return false
@@ -197,7 +197,7 @@ var _ = Describe("Installer test", func() {
 		checkDeploymentDeleted = func() {
 			By("Checking deployment Deleted. deployment name: " + deploymentName)
 			Eventually(func() bool {
-				_, err := f.KubeClient.AppsV1beta1().Deployments(root.Namespace()).Get(deploymentName, metav1.GetOptions{})
+				_, err := f.KubeClient.AppsV1().Deployments(root.Namespace()).Get(deploymentName, metav1.GetOptions{})
 				return kerr.IsNotFound(err) || kerr.IsGone(err)
 			}, timeOut, pollingInterval).Should(BeTrue())
 		}

--- a/test/e2e/matcher/replica_matcher.go
+++ b/test/e2e/matcher/replica_matcher.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/onsi/gomega/types"
-	apps "k8s.io/api/apps/v1beta1"
+	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 )


### PR DESCRIPTION
Kubernetes 1.16 removed old versions of API: https://github.com/kubernetes/kubernetes/pull/70672

This PR migrates from `apps/v1beta1` to `apps/v1` (`apps/v1` is available from version kubernetes 1.9) and add livenessProbe for guard