### PR TITLE
Add flag to call Graph api only when overage indicator is present

### DIFF
--- a/auth/providers/azure/options.go
+++ b/auth/providers/azure/options.go
@@ -37,13 +37,14 @@ const (
 )
 
 type Options struct {
-	Environment  string
-	ClientID     string
-	ClientSecret string
-	TenantID     string
-	UseGroupUID  bool
-	AuthMode     string
-	AKSTokenURL  string
+	Environment                              string
+	ClientID                                 string
+	ClientSecret                             string
+	TenantID                                 string
+	UseGroupUID                              bool
+	AuthMode                                 string
+	AKSTokenURL                              string
+	ResolveGroupMembershipOnlyOnOverageClaim bool
 }
 
 func NewOptions() Options {
@@ -61,6 +62,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseGroupUID, "azure.use-group-uid", o.UseGroupUID, "Use group UID for authentication instead of group display name")
 	fs.StringVar(&o.AuthMode, "azure.auth-mode", "client-credential", "auth mode to call graph api, valid value is either aks, obo, or client-credential")
 	fs.StringVar(&o.AKSTokenURL, "azure.aks-token-url", "", "url to call for AKS OBO flow")
+	fs.BoolVar(&o.ResolveGroupMembershipOnlyOnOverageClaim, "azure.graph-call-on-overage-claim", o.ResolveGroupMembershipOnlyOnOverageClaim, "set to true to resolve group membership only when overage claim is present. setting to false will always call graph api to resolve group membership")
 }
 
 func (o *Options) Validate() []error {
@@ -165,6 +167,8 @@ func (o Options) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err erro
 	}
 
 	args = append(args, fmt.Sprintf("--azure.use-group-uid=%t", o.UseGroupUID))
+
+	args = append(args, fmt.Sprintf("--azure.graph-call-on-overage-claim=%t", o.ResolveGroupMembershipOnlyOnOverageClaim))
 
 	container.Args = args
 	d.Spec.Template.Spec.Containers[0] = container

--- a/docs/guides/authenticator/azure.md
+++ b/docs/guides/authenticator/azure.md
@@ -192,7 +192,17 @@ The access token is acquired when first `kubectl` command is executed
 
 After signing in a web browser, the token is stored in the configuration, and it will be reused when executing next commands.
 
+### Skip Graph API call when overage indicator is not present
+
+When the client is configured to emit `groups` claim, it is possible to skip Graph api call when there is no overage indicator.
+To enable skipping the graph api call, add below option to guard
+
+```console
+    --azure.graph-call-on-overage-claim
+```
+
 ## Further Reading:
 - https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications
 - https://github.com/kubernetes/client-go/blob/master/plugin/pkg/client/auth/azure/README.md
 - https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow
+- https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#payload-claims


### PR DESCRIPTION
This PR enables an optimization to skip calling to Graph api when any of below conditions satisfies
1. `groups` claim is already present
1. overage claim is not present

It fixes #171 
