### PR TITLE
Azure: switch to new graph endpoint for US Government cloud

### DIFF
--- a/auth/providers/azure/azure.go
+++ b/auth/providers/azure/azure.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/appscode/guard/auth"
 	"github.com/appscode/guard/auth/providers/azure/graph"
@@ -316,9 +317,14 @@ func getAuthInfo(environment, tenantID string, getMetadata func(string, string) 
 		return nil, errors.Wrap(err, "failed to get metadata for azure")
 	}
 
+	msgraphHost := metadata.MsgraphHost
+	if strings.EqualFold(azure.USGovernmentCloud.Name, environment) {
+		msgraphHost = "graph.microsoft.us"
+	}
+
 	return &authInfo{
 		AADEndpoint: env.ActiveDirectoryEndpoint,
-		MSGraphHost: metadata.MsgraphHost,
+		MSGraphHost: msgraphHost,
 		Issuer:      metadata.Issuer,
 	}, nil
 }


### PR DESCRIPTION
The graph endpoint in metadata for US Government cloud is in correct, always stick to new endpoint.

Reference:
https://docs.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints