### PR TITLE
Changed azure authz support to use v1beta1 version instead of v1 for SubjectAccessReview

### DIFF
--- a/authz/providers/azure/azure_test.go
+++ b/authz/providers/azure/azure_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/appscode/pat"
 
 	"github.com/stretchr/testify/assert"
-	authzv1 "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
 
 const (
@@ -131,10 +131,10 @@ func TestCheck(t *testing.T) {
 		defer srv.Close()
 		defer store.Close()
 
-		request := &authzv1.SubjectAccessReviewSpec{
+		request := &authzv1beta1.SubjectAccessReviewSpec{
 			User: "beta@bing.com",
-			ResourceAttributes: &authzv1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
-				Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}, Extra: map[string]authzv1.ExtraValue{"oid": {"00000000-0000-0000-0000-000000000000"}}}
+			ResourceAttributes: &authzv1beta1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
+				Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}, Extra: map[string]authzv1beta1.ExtraValue{"oid": {"00000000-0000-0000-0000-000000000000"}}}
 
 		resp, err := client.Check(request, store)
 		assert.Nilf(t, err, "Should not have got error")

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	authzv1 "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
 
 const (
@@ -123,7 +123,7 @@ type AuthorizationDecision struct {
 	TimeToLiveInMs      int                 `json:"timeToLiveInMs"`
 }
 
-func getScope(resourceId string, attr *authzv1.ResourceAttributes) string {
+func getScope(resourceId string, attr *authzv1beta1.ResourceAttributes) string {
 	if attr != nil && attr.Namespace != "" {
 		return path.Join(resourceId, namespaces, attr.Namespace)
 	}
@@ -189,7 +189,7 @@ func getActionName(verb string) string {
 	}
 }
 
-func getDataAction(subRevReq *authzv1.SubjectAccessReviewSpec, clusterType string) AuthorizationActionInfo {
+func getDataAction(subRevReq *authzv1beta1.SubjectAccessReviewSpec, clusterType string) AuthorizationActionInfo {
 	authInfo := AuthorizationActionInfo{
 		IsDataAction: true}
 
@@ -212,7 +212,7 @@ func defaultDir(s string) string {
 	return "-" // invalid for a namespace
 }
 
-func getResultCacheKey(subRevReq *authzv1.SubjectAccessReviewSpec) string {
+func getResultCacheKey(subRevReq *authzv1beta1.SubjectAccessReviewSpec) string {
 	cacheKey := subRevReq.User
 
 	if subRevReq.ResourceAttributes != nil {
@@ -226,7 +226,7 @@ func getResultCacheKey(subRevReq *authzv1.SubjectAccessReviewSpec) string {
 	return cacheKey
 }
 
-func prepareCheckAccessRequestBody(req *authzv1.SubjectAccessReviewSpec, clusterType, resourceId string, retrieveGroupMemberships bool) (*CheckAccessRequest, error) {
+func prepareCheckAccessRequestBody(req *authzv1beta1.SubjectAccessReviewSpec, clusterType, resourceId string, retrieveGroupMemberships bool) (*CheckAccessRequest, error) {
 	/* This is how sample SubjectAccessReview request will look like
 	{
 		"kind": "SubjectAccessReview",
@@ -303,7 +303,7 @@ func prepareCheckAccessRequestBody(req *authzv1.SubjectAccessReviewSpec, cluster
 	return &checkaccessreq, nil
 }
 
-func getNameSpaceScope(req *authzv1.SubjectAccessReviewSpec) (bool, string) {
+func getNameSpaceScope(req *authzv1beta1.SubjectAccessReviewSpec) (bool, string) {
 	var namespace string = ""
 	if req.ResourceAttributes != nil && req.ResourceAttributes.Namespace != "" {
 		namespace = path.Join(namespaces, req.ResourceAttributes.Namespace)
@@ -312,7 +312,7 @@ func getNameSpaceScope(req *authzv1.SubjectAccessReviewSpec) (bool, string) {
 	return false, namespace
 }
 
-func ConvertCheckAccessResponse(body []byte) (*authzv1.SubjectAccessReviewStatus, error) {
+func ConvertCheckAccessResponse(body []byte) (*authzv1beta1.SubjectAccessReviewStatus, error) {
 	var (
 		response []AuthorizationDecision
 		allowed  bool
@@ -335,5 +335,5 @@ func ConvertCheckAccessResponse(body []byte) (*authzv1.SubjectAccessReviewStatus
 		verdict = AccessNotAllowedVerdict
 	}
 
-	return &authzv1.SubjectAccessReviewStatus{Allowed: allowed, Reason: verdict, Denied: denied}, nil
+	return &authzv1beta1.SubjectAccessReviewStatus{Allowed: allowed, Reason: verdict, Denied: denied}, nil
 }

--- a/authz/providers/azure/rbac/checkaccessreqhelper_test.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper_test.go
@@ -21,13 +21,13 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	authzv1 "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
 
 func Test_getScope(t *testing.T) {
 	type args struct {
 		resourceId string
-		attr       *authzv1.ResourceAttributes
+		attr       *authzv1beta1.ResourceAttributes
 	}
 	tests := []struct {
 		name string
@@ -36,9 +36,9 @@ func Test_getScope(t *testing.T) {
 	}{
 		{"nilAttr", args{"resourceId", nil}, "resourceId"},
 		{"bothnil", args{"", nil}, ""},
-		{"emptyRes", args{"", &authzv1.ResourceAttributes{Namespace: ""}}, ""},
-		{"emptyNS", args{"resourceId", &authzv1.ResourceAttributes{Namespace: ""}}, "resourceId"},
-		{"bothPresent", args{"resourceId", &authzv1.ResourceAttributes{Namespace: "test"}}, "resourceId/namespaces/test"},
+		{"emptyRes", args{"", &authzv1beta1.ResourceAttributes{Namespace: ""}}, ""},
+		{"emptyNS", args{"resourceId", &authzv1beta1.ResourceAttributes{Namespace: ""}}, "resourceId"},
+		{"bothPresent", args{"resourceId", &authzv1beta1.ResourceAttributes{Namespace: "test"}}, "resourceId/namespaces/test"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -76,7 +76,7 @@ func Test_getValidSecurityGroups(t *testing.T) {
 
 func Test_getDataAction(t *testing.T) {
 	type args struct {
-		subRevReq   *authzv1.SubjectAccessReviewSpec
+		subRevReq   *authzv1beta1.SubjectAccessReviewSpec
 		clusterType string
 	}
 	tests := []struct {
@@ -85,63 +85,63 @@ func Test_getDataAction(t *testing.T) {
 		want AuthorizationActionInfo
 	}{
 		{"aks", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				NonResourceAttributes: &authzv1.NonResourceAttributes{Path: "/apis", Verb: "list"}}, clusterType: "aks"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				NonResourceAttributes: &authzv1beta1.NonResourceAttributes{Path: "/apis", Verb: "list"}}, clusterType: "aks"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "aks/apis/read"}, IsDataAction: true}},
 
 		{"aks2", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				NonResourceAttributes: &authzv1.NonResourceAttributes{Path: "/logs", Verb: "get"}}, clusterType: "aks"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				NonResourceAttributes: &authzv1beta1.NonResourceAttributes{Path: "/logs", Verb: "get"}}, clusterType: "aks"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "aks/logs/read"}, IsDataAction: true}},
 
 		{"arc", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "", Resource: "pods", Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}}, clusterType: "arc"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "", Resource: "pods", Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}}, clusterType: "arc"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "arc/pods/delete"}, IsDataAction: true}},
 
 		{"arc2", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "apps", Resource: "deployments", Subresource: "status", Version: "v1", Name: "test", Verb: "create"}}, clusterType: "arc"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "apps", Resource: "deployments", Subresource: "status", Version: "v1", Name: "test", Verb: "create"}}, clusterType: "arc"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "arc/apps/deployments/write"}, IsDataAction: true}},
 
 		{"arc3", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "policy", Resource: "podsecuritypolicies", Subresource: "status", Version: "v1", Name: "test", Verb: "use"}}, clusterType: "arc"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "policy", Resource: "podsecuritypolicies", Subresource: "status", Version: "v1", Name: "test", Verb: "use"}}, clusterType: "arc"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "arc/policy/podsecuritypolicies/use/action"}, IsDataAction: true}},
 
 		{"aks3", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "authentication.k8s.io", Resource: "userextras", Subresource: "scopes", Version: "v1", Name: "test", Verb: "impersonate"}}, clusterType: "aks"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "authentication.k8s.io", Resource: "userextras", Subresource: "scopes", Version: "v1", Name: "test", Verb: "impersonate"}}, clusterType: "aks"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "aks/authentication.k8s.io/userextras/impersonate/action"}, IsDataAction: true}},
 
 		{"arc4", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Subresource: "status", Version: "v1", Name: "test", Verb: "bind"}}, clusterType: "arc"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Subresource: "status", Version: "v1", Name: "test", Verb: "bind"}}, clusterType: "arc"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "arc/rbac.authorization.k8s.io/clusterroles/bind/action"}, IsDataAction: true}},
 
 		{"aks4", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Subresource: "status", Version: "v1", Name: "test", Verb: "escalate"}}, clusterType: "aks"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Subresource: "status", Version: "v1", Name: "test", Verb: "escalate"}}, clusterType: "aks"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "aks/rbac.authorization.k8s.io/clusterroles/escalate/action"}, IsDataAction: true}},
 
 		{"arc5", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "scheduling.k8s.io", Resource: "priorityclasses", Subresource: "status", Version: "v1", Name: "test", Verb: "update"}}, clusterType: "arc"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "scheduling.k8s.io", Resource: "priorityclasses", Subresource: "status", Version: "v1", Name: "test", Verb: "update"}}, clusterType: "arc"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "arc/scheduling.k8s.io/priorityclasses/write"}, IsDataAction: true}},
 
 		{"aks5", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "events.k8s.io", Resource: "events", Subresource: "status", Version: "v1", Name: "test", Verb: "watch"}}, clusterType: "aks"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "events.k8s.io", Resource: "events", Subresource: "status", Version: "v1", Name: "test", Verb: "watch"}}, clusterType: "aks"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "aks/events.k8s.io/events/read"}, IsDataAction: true}},
 
 		{"arc6", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "batch", Resource: "cronjobs", Subresource: "status", Version: "v1", Name: "test", Verb: "patch"}}, clusterType: "arc"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "batch", Resource: "cronjobs", Subresource: "status", Version: "v1", Name: "test", Verb: "patch"}}, clusterType: "arc"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "arc/batch/cronjobs/write"}, IsDataAction: true}},
 
 		{"aks6", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
-				ResourceAttributes: &authzv1.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Subresource: "approvals", Version: "v1", Name: "test", Verb: "deletecollection"}}, clusterType: "aks"},
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Subresource: "approvals", Version: "v1", Name: "test", Verb: "deletecollection"}}, clusterType: "aks"},
 			AuthorizationActionInfo{AuthorizationEntity: AuthorizationEntity{Id: "aks/certificates.k8s.io/certificatesigningrequests/delete"}, IsDataAction: true}},
 	}
 	for _, tt := range tests {
@@ -154,23 +154,23 @@ func Test_getDataAction(t *testing.T) {
 }
 
 func Test_getNameSpaceScope(t *testing.T) {
-	req := authzv1.SubjectAccessReviewSpec{ResourceAttributes: nil}
+	req := authzv1beta1.SubjectAccessReviewSpec{ResourceAttributes: nil}
 	want := false
 	got, str := getNameSpaceScope(&req)
 	if got || str != "" {
 		t.Errorf("Want:%v, got:%v", want, got)
 	}
 
-	req = authzv1.SubjectAccessReviewSpec{
-		ResourceAttributes: &authzv1.ResourceAttributes{Namespace: ""}}
+	req = authzv1beta1.SubjectAccessReviewSpec{
+		ResourceAttributes: &authzv1beta1.ResourceAttributes{Namespace: ""}}
 	want = false
 	got, str = getNameSpaceScope(&req)
 	if got || str != "" {
 		t.Errorf("Want:%v, got:%v", want, got)
 	}
 
-	req = authzv1.SubjectAccessReviewSpec{
-		ResourceAttributes: &authzv1.ResourceAttributes{Namespace: "dev"}}
+	req = authzv1beta1.SubjectAccessReviewSpec{
+		ResourceAttributes: &authzv1beta1.ResourceAttributes{Namespace: "dev"}}
 	outputstring := "namespaces/dev"
 	want = true
 	got, str = getNameSpaceScope(&req)
@@ -180,7 +180,7 @@ func Test_getNameSpaceScope(t *testing.T) {
 }
 
 func Test_prepareCheckAccessRequestBody(t *testing.T) {
-	req := &authzv1.SubjectAccessReviewSpec{Extra: nil}
+	req := &authzv1beta1.SubjectAccessReviewSpec{Extra: nil}
 	resouceId := "resourceId"
 	clusterType := "aks"
 	var want *CheckAccessRequest = nil
@@ -192,7 +192,7 @@ func Test_prepareCheckAccessRequestBody(t *testing.T) {
 		t.Errorf("Want:%v WantErr:%v, got:%v, gotErr:%v", want, wantErr, got, gotErr)
 	}
 
-	req = &authzv1.SubjectAccessReviewSpec{Extra: map[string]authzv1.ExtraValue{"oid": {"test"}}}
+	req = &authzv1beta1.SubjectAccessReviewSpec{Extra: map[string]authzv1beta1.ExtraValue{"oid": {"test"}}}
 	resouceId = "resourceId"
 	clusterType = "arc"
 	want = nil
@@ -207,7 +207,7 @@ func Test_prepareCheckAccessRequestBody(t *testing.T) {
 
 func Test_getResultCacheKey(t *testing.T) {
 	type args struct {
-		subRevReq *authzv1.SubjectAccessReviewSpec
+		subRevReq *authzv1beta1.SubjectAccessReviewSpec
 	}
 	tests := []struct {
 		name string
@@ -215,36 +215,36 @@ func Test_getResultCacheKey(t *testing.T) {
 		want string
 	}{
 		{"aks", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
 				User:                  "charlie@yahoo.com",
-				NonResourceAttributes: &authzv1.NonResourceAttributes{Path: "/apis/v1", Verb: "list"}}},
+				NonResourceAttributes: &authzv1beta1.NonResourceAttributes{Path: "/apis/v1", Verb: "list"}}},
 			"charlie@yahoo.com/apis/v1/read"},
 
 		{"aks", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
 				User:                  "echo@outlook.com",
-				NonResourceAttributes: &authzv1.NonResourceAttributes{Path: "/logs", Verb: "get"}}},
+				NonResourceAttributes: &authzv1beta1.NonResourceAttributes{Path: "/logs", Verb: "get"}}},
 			"echo@outlook.com/logs/read"},
 
 		{"aks", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
 				User: "alpha@bing.com",
-				ResourceAttributes: &authzv1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
 					Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}}},
 			"alpha@bing.com/dev/-/pods/delete"},
 
 		{"arc", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
 				User: "beta@msn.com",
-				ResourceAttributes: &authzv1.ResourceAttributes{Namespace: "azure-arc",
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Namespace: "azure-arc",
 					Group: "authentication.k8s.io", Resource: "userextras", Subresource: "scopes", Version: "v1",
 					Name: "test", Verb: "impersonate"}}},
 			"beta@msn.com/azure-arc/authentication.k8s.io/userextras/impersonate/action"},
 
 		{"arc", args{
-			subRevReq: &authzv1.SubjectAccessReviewSpec{
+			subRevReq: &authzv1beta1.SubjectAccessReviewSpec{
 				User: "beta@msn.com",
-				ResourceAttributes: &authzv1.ResourceAttributes{Namespace: "", Group: "", Resource: "nodes",
+				ResourceAttributes: &authzv1beta1.ResourceAttributes{Namespace: "", Group: "", Resource: "nodes",
 					Subresource: "scopes", Version: "v1", Name: "", Verb: "list"}}},
 			"beta@msn.com/-/-/nodes/read"},
 	}

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -37,7 +37,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/moul/http2curl"
 	"github.com/pkg/errors"
-	authzv1 "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
 
 const (
@@ -161,7 +161,7 @@ func (a *AccessInfo) ShouldSkipAuthzCheckForNonAADUsers() bool {
 	return a.skipAuthzForNonAADUsers
 }
 
-func (a *AccessInfo) GetResultFromCache(request *authzv1.SubjectAccessReviewSpec, store authz.Store) (bool, bool) {
+func (a *AccessInfo) GetResultFromCache(request *authzv1beta1.SubjectAccessReviewSpec, store authz.Store) (bool, bool) {
 	var result bool
 	key := getResultCacheKey(request)
 	glog.V(10).Infof("Cache search for key: %s", key)
@@ -169,7 +169,7 @@ func (a *AccessInfo) GetResultFromCache(request *authzv1.SubjectAccessReviewSpec
 	return found, result
 }
 
-func (a *AccessInfo) SkipAuthzCheck(request *authzv1.SubjectAccessReviewSpec) bool {
+func (a *AccessInfo) SkipAuthzCheck(request *authzv1beta1.SubjectAccessReviewSpec) bool {
 	if a.clusterType == connectedClusters {
 		_, ok := a.skipCheck[strings.ToLower(request.User)]
 		return ok
@@ -177,13 +177,13 @@ func (a *AccessInfo) SkipAuthzCheck(request *authzv1.SubjectAccessReviewSpec) bo
 	return false
 }
 
-func (a *AccessInfo) SetResultInCache(request *authzv1.SubjectAccessReviewSpec, result bool, store authz.Store) error {
+func (a *AccessInfo) SetResultInCache(request *authzv1beta1.SubjectAccessReviewSpec, result bool, store authz.Store) error {
 	key := getResultCacheKey(request)
 	glog.V(10).Infof("Cache set for key: %s, value: %t", key, result)
 	return store.Set(key, result)
 }
 
-func (a *AccessInfo) AllowNonResPathDiscoveryAccess(request *authzv1.SubjectAccessReviewSpec) bool {
+func (a *AccessInfo) AllowNonResPathDiscoveryAccess(request *authzv1beta1.SubjectAccessReviewSpec) bool {
 	if request.NonResourceAttributes != nil && a.allowNonResDiscoveryPathAccess && strings.EqualFold(request.NonResourceAttributes.Verb, "get") {
 		path := strings.ToLower(request.NonResourceAttributes.Path)
 		if strings.HasPrefix(path, "/api") || strings.HasPrefix(path, "/openapi") || strings.HasPrefix(path, "/version") || strings.HasPrefix(path, "/healthz") {
@@ -206,7 +206,7 @@ func (a *AccessInfo) setReqHeaders(req *http.Request) {
 	}
 }
 
-func (a *AccessInfo) CheckAccess(request *authzv1.SubjectAccessReviewSpec) (*authzv1.SubjectAccessReviewStatus, error) {
+func (a *AccessInfo) CheckAccess(request *authzv1beta1.SubjectAccessReviewSpec) (*authzv1beta1.SubjectAccessReviewStatus, error) {
 	checkAccessBody, err := prepareCheckAccessRequestBody(request, a.clusterType, a.azureResourceId, a.retrieveGroupMemberships)
 
 	if err != nil {

--- a/authz/providers/azure/rbac/rbac_test.go
+++ b/authz/providers/azure/rbac/rbac_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/appscode/guard/auth/providers/azure/graph"
 
 	"github.com/stretchr/testify/assert"
-	authzv1 "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
 
 func getAPIServerAndAccessInfo(returnCode int, body, clusterType, resourceId string) (*httptest.Server, *AccessInfo) {
@@ -57,10 +57,10 @@ func TestCheckAccess(t *testing.T) {
 		ts, u := getAPIServerAndAccessInfo(http.StatusOK, validBody, "arc", "resourceid")
 		defer ts.Close()
 
-		request := &authzv1.SubjectAccessReviewSpec{
+		request := &authzv1beta1.SubjectAccessReviewSpec{
 			User: "alpha@bing.com",
-			ResourceAttributes: &authzv1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
-				Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}, Extra: map[string]authzv1.ExtraValue{"oid": {"00000000-0000-0000-0000-000000000000"}}}
+			ResourceAttributes: &authzv1beta1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
+				Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}, Extra: map[string]authzv1beta1.ExtraValue{"oid": {"00000000-0000-0000-0000-000000000000"}}}
 
 		response, err := u.CheckAccess(request)
 
@@ -76,10 +76,10 @@ func TestCheckAccess(t *testing.T) {
 		ts, u := getAPIServerAndAccessInfo(http.StatusTooManyRequests, validBody, "arc", "resourceid")
 		defer ts.Close()
 
-		request := &authzv1.SubjectAccessReviewSpec{
+		request := &authzv1beta1.SubjectAccessReviewSpec{
 			User: "alpha@bing.com",
-			ResourceAttributes: &authzv1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
-				Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}, Extra: map[string]authzv1.ExtraValue{"oid": {"00000000-0000-0000-0000-000000000000"}}}
+			ResourceAttributes: &authzv1beta1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
+				Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}, Extra: map[string]authzv1beta1.ExtraValue{"oid": {"00000000-0000-0000-0000-000000000000"}}}
 
 		response, err := u.CheckAccess(request)
 
@@ -94,10 +94,10 @@ func TestCheckAccess(t *testing.T) {
 			"arc", "resourceid")
 		defer ts.Close()
 
-		request := &authzv1.SubjectAccessReviewSpec{
+		request := &authzv1beta1.SubjectAccessReviewSpec{
 			User: "alpha@bing.com",
-			ResourceAttributes: &authzv1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
-				Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}, Extra: map[string]authzv1.ExtraValue{"oid": {"00000000-0000-0000-0000-000000000000"}}}
+			ResourceAttributes: &authzv1beta1.ResourceAttributes{Namespace: "dev", Group: "", Resource: "pods",
+				Subresource: "status", Version: "v1", Name: "test", Verb: "delete"}, Extra: map[string]authzv1beta1.ExtraValue{"oid": {"00000000-0000-0000-0000-000000000000"}}}
 
 		response, err := u.CheckAccess(request)
 

--- a/authz/types.go
+++ b/authz/types.go
@@ -19,7 +19,7 @@ import (
 	"sort"
 	"strings"
 
-	authzv1 "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
 
 type orgs []string
@@ -46,7 +46,7 @@ func (o orgs) String() string {
 }
 
 type Interface interface {
-	Check(request *authzv1.SubjectAccessReviewSpec, store Store) (*authzv1.SubjectAccessReviewStatus, error)
+	Check(request *authzv1beta1.SubjectAccessReviewSpec, store Store) (*authzv1beta1.SubjectAccessReviewStatus, error)
 }
 
 type Store interface {

--- a/server/authzhandler.go
+++ b/server/authzhandler.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	authzv1 "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 )
 
 type Authzhandler struct {
@@ -46,7 +46,7 @@ func (s *Authzhandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	org := crt.Subject.Organization[0]
 	glog.Infof("Received subject access review request for %s/%s", org, crt.Subject.CommonName)
 
-	data := authzv1.SubjectAccessReview{}
+	data := authzv1beta1.SubjectAccessReview{}
 	err := json.NewDecoder(req.Body).Decode(&data)
 	if err != nil {
 		writeAuthzResponse(w, nil, nil, WithCode(errors.Wrap(err, "Failed to parse request"), http.StatusBadRequest))

--- a/server/utils.go
+++ b/server/utils.go
@@ -25,7 +25,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	auth "k8s.io/api/authentication/v1"
-	authz "k8s.io/api/authorization/v1"
+	authzv1beta1 "k8s.io/api/authorization/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -75,13 +75,13 @@ func write(w http.ResponseWriter, info *auth.UserInfo, err error) {
 	}
 }
 
-func writeAuthzResponse(w http.ResponseWriter, spec *authz.SubjectAccessReviewSpec, accessInfo *authz.SubjectAccessReviewStatus, err error) {
+func writeAuthzResponse(w http.ResponseWriter, spec *authzv1beta1.SubjectAccessReviewSpec, accessInfo *authzv1beta1.SubjectAccessReviewStatus, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("x-content-type-options", "nosniff")
 
-	resp := authz.SubjectAccessReview{
+	resp := authzv1beta1.SubjectAccessReview{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: authz.SchemeGroupVersion.String(),
+			APIVersion: authzv1beta1.SchemeGroupVersion.String(),
 			Kind:       "SubjectAccessReview",
 		},
 	}
@@ -93,7 +93,7 @@ func writeAuthzResponse(w http.ResponseWriter, spec *authz.SubjectAccessReviewSp
 	if accessInfo != nil {
 		resp.Status = *accessInfo
 	} else {
-		accessInfo := authz.SubjectAccessReviewStatus{Allowed: false, Denied: true}
+		accessInfo := authzv1beta1.SubjectAccessReviewStatus{Allowed: false, Denied: true}
 		if err != nil {
 			accessInfo.Reason = err.Error()
 		}


### PR DESCRIPTION
Making this change as even though we are expecting v1 version of SAR, we are still getting v1beta1 version. Also, in v1beta1 version there is k8s bug where instead of "groups" SAR decodes it as "group". Even though this is fixed in v1, we are not being able to use v1 version. Will be raising a bug on k8s on this regarding how we can use v1 version. Till then as we don't want to explicity call graph every time to get the groups, we are changing to use v1beta1 version so that we can get the groups the user is part of


Signed-off-by: Anumita Shenoy <ansheno@microsoft.com>