### PR TITLE
Add proxy support in Guard (#20)

### DIFF
--- a/auth/providers/azure/graph/aks_tokenprovider.go
+++ b/auth/providers/azure/graph/aks_tokenprovider.go
@@ -33,9 +33,12 @@ type aksTokenProvider struct {
 
 // NewAKSTokenProvider returns a TokenProvider that implements On-Behalf-Of flow using AKS first party service
 func NewAKSTokenProvider(tokenURL, tenantID string) TokenProvider {
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
 	return &aksTokenProvider{
 		name:     "AKSTokenProvider",
-		client:   &http.Client{},
+		client:   &http.Client{Transport: tr},
 		tokenURL: tokenURL,
 		tenantID: tenantID,
 	}

--- a/auth/providers/azure/graph/clientcredential_tokenprovider.go
+++ b/auth/providers/azure/graph/clientcredential_tokenprovider.go
@@ -39,9 +39,12 @@ type clientCredentialTokenProvider struct {
 // NewClientCredentialTokenProvider returns a TokenProvider that implements OAuth client credential flow on Azure Active Directory
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#get-a-token
 func NewClientCredentialTokenProvider(clientID, clientSecret, loginURL, scope string) TokenProvider {
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
 	return &clientCredentialTokenProvider{
 		name:         "ClientCredentialTokenProvider",
-		client:       &http.Client{},
+		client:       &http.Client{Transport: tr},
 		clientID:     clientID,
 		clientSecret: clientSecret,
 		scope:        scope,

--- a/auth/providers/azure/graph/graph.go
+++ b/auth/providers/azure/graph/graph.go
@@ -78,6 +78,11 @@ func (u *UserInfo) getGroupIDs(userPrincipal string) ([]string, error) {
 	}
 	// Set the auth headers for the request
 	req.Header = u.headers
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
+
+	u.client.Transport = tr
 
 	resp, err := u.client.Do(req)
 	if err != nil {

--- a/auth/providers/azure/graph/obo_tokenprovider.go
+++ b/auth/providers/azure/graph/obo_tokenprovider.go
@@ -39,9 +39,12 @@ type oboTokenProvider struct {
 // NewOBOTokenProvider returns a TokenProvider that implements OAuth On-Behalf-Of flow on Azure Active Directory
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow
 func NewOBOTokenProvider(clientID, clientSecret, loginURL, scope string) TokenProvider {
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
 	return &oboTokenProvider{
 		name:         "OBOTokenProvider",
-		client:       &http.Client{},
+		client:       &http.Client{Transport: tr},
 		clientID:     clientID,
 		clientSecret: clientSecret,
 		scope:        scope,

--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -38,6 +38,10 @@ const (
 	NonAADUserNotAllowedVerdict = "Access denied by Azure RBAC for non AAD users. Configure --azure.skip-authz-for-non-aad-users to enable access. If you are an AAD user, please set Extra:oid parameter for impersonated user in the kubeconfig."
 )
 
+var (
+	username string
+)
+
 type SubjectInfoAttributes struct {
 	ObjectId string   `json:"ObjectId"`
 	Groups   []string `json:"Groups,omitempty"`
@@ -293,6 +297,7 @@ func prepareCheckAccessRequestBody(req *authzv1beta1.SubjectAccessReviewSpec, cl
 	groups := getValidSecurityGroups(req.Groups)
 	checkaccessreq.Subject.Attributes.Groups = groups
 
+	username = req.User
 	action := make([]AuthorizationActionInfo, 1)
 	action[0] = getDataAction(req, clusterType)
 	checkaccessreq.Actions = action
@@ -326,7 +331,7 @@ func ConvertCheckAccessResponse(body []byte) (*authzv1beta1.SubjectAccessReviewS
 
 	if strings.ToLower(response[0].Decision) == Allowed {
 		allowed = true
-		verdict = fmt.Sprintf(AccessAllowedVerboseVerdict, response[0].AzureRoleAssignment.Id, response[0].AzureRoleAssignment.RoleDefinitionId, response[0].AzureRoleAssignment.PrincipalId)
+		verdict = fmt.Sprintf(AccessAllowedVerboseVerdict, response[0].AzureRoleAssignment.Id, response[0].AzureRoleAssignment.RoleDefinitionId, username)
 	} else {
 		allowed = false
 		denied = true

--- a/docs/reference/guard_get_installer.md
+++ b/docs/reference/guard_get_installer.md
@@ -69,6 +69,10 @@ guard get installer [flags]
   -n, --namespace string                     Name of Kubernetes namespace used to run guard server. (default "kube-system")
       --pki-dir string                       Path to directory where pki files are stored. (default "$HOME/.guard")
       --private-registry string              Private Docker registry (default "appscode")
+      --proxy-https                          Https proxy URL to be used
+      --proxy-http                           Http proxy URL to be used
+      --proxy-skip-range                     List of URLs/CIDRs for which proxy should not to be used
+      --proxy-cert                           Path to the certificate file for proxy
       --run-on-master                        If true, runs Guard server on master instances (default true)
       --token-auth-file string               To enable static token authentication
 ```

--- a/installer/options.go
+++ b/installer/options.go
@@ -35,12 +35,17 @@ import (
 )
 
 type AuthOptions struct {
+	VerbosityLevel  string
 	PkiDir          string
 	Namespace       string
 	Addr            string
 	RunOnMaster     bool
 	PrivateRegistry string
 	imagePullSecret string
+	HttpsProxy      string
+	HttpProxy       string
+	NoProxy         string
+	ProxyCert       string
 
 	AuthProvider providers.AuthProviders
 	Token        token.Options
@@ -58,6 +63,7 @@ type AuthzOptions struct {
 
 func NewAuthOptions() AuthOptions {
 	return AuthOptions{
+		VerbosityLevel:  "3",
 		PkiDir:          auth.DefaultDataDir,
 		Namespace:       metav1.NamespaceSystem,
 		Addr:            "10.96.10.96:443",
@@ -79,12 +85,17 @@ func NewAuthzOptions() AuthzOptions {
 }
 
 func (o *AuthOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.VerbosityLevel, "v", o.VerbosityLevel, "Log level for V logs")
 	fs.StringVar(&o.PkiDir, "pki-dir", o.PkiDir, "Path to directory where pki files are stored.")
 	fs.StringVarP(&o.Namespace, "namespace", "n", o.Namespace, "Name of Kubernetes namespace used to run guard server.")
 	fs.StringVar(&o.Addr, "addr", o.Addr, "Address (host:port) of guard server.")
 	fs.BoolVar(&o.RunOnMaster, "run-on-master", o.RunOnMaster, "If true, runs Guard server on master instances")
 	fs.StringVar(&o.PrivateRegistry, "private-registry", o.PrivateRegistry, "Private Docker registry")
 	fs.StringVar(&o.imagePullSecret, "image-pull-secret", o.imagePullSecret, "Name of image pull secret")
+	fs.StringVar(&o.HttpsProxy, "proxy-https", o.HttpsProxy, "Https proxy URL to be used")
+	fs.StringVar(&o.HttpProxy, "proxy-http", o.HttpProxy, "Http proxy URL to be used")
+	fs.StringVar(&o.NoProxy, "proxy-skip-range", o.NoProxy, "List of URLs/CIDRs for which proxy should not to be used")
+	fs.StringVar(&o.ProxyCert, "proxy-cert", o.ProxyCert, "Path to the certificate file for proxy")
 	o.AuthProvider.AddFlags(fs)
 	o.Token.AddFlags(fs)
 	o.Google.AddFlags(fs)

--- a/installer/secrets.go
+++ b/installer/secrets.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Guard Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"io/ioutil"
+
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func newProxySecret(namespace string, httpsProxy string, httpProxy string, noProxy string) runtime.Object {
+
+	return &core.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guard-proxy",
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Type: core.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"HTTP_PROXY":  []byte(httpProxy),
+			"HTTPS_PROXY": []byte(httpsProxy),
+			"NO_PROXY":    []byte(noProxy),
+		},
+	}
+}
+
+func newProxyCertSecret(namespace string, proxyCert string) (runtime.Object, error) {
+	cert, err := ioutil.ReadFile(proxyCert)
+	if err != nil {
+		return nil, err
+	}
+
+	return &core.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "guard-proxy-cert",
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Type: core.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"proxy-cert.crt": cert,
+		},
+	}, nil
+}


### PR DESCRIPTION
Added proxy support for guard and additional metrics for authz

Proxy Support
Added 4 parameters for proxy in the installer command
1. 3 are for the common proxy environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) -  "guard-proxy" secret (installer/secrets.go) is created which is loaded as environment variable in the deployment.yaml. 
     --proxy-http, --proxy-https, --proxy-skip-range
2. --proxy-cert is for proxy with cert authentication. For this, user provides the path to their proxy cert to the --proxy-cert args. Internally, we read the data from the file and create another secret ("guard-proxy-cert"). For proxy with cert, the cert should be part of "/etc/ssl/certs/ca-certificates.pem". This is achieved by running update-ca-certificates command. The update-ca-certificates command takes the certs present in /usr/local/share/ca-certificates and adds them to  /etc/ssl/certs/ca-certificates.pem. To achieve this, we are doing the following:
    -  create two volumes , one is empty directory volume called "ssl-certs" and the other is a volume created from the "guard-proxy-cert" secret called "proxy-certstore". 
    -  An init container (image: nginx:stable-alpine (9 mb)) which does the job of running the update-ca-certificates command. To this container we mount the "ssl-certs" volume at path "/etc/ssl/certs" and the "proxy-certstore" volume at "/usr/local/share/ca-certificates" path. The container will run update-ca-certificates and create the ca-certificates.pem file in the /etc/ssl/certs directory which is from the volume.
   - The main "guard" container has the "ssl-certs" volume mounted at /etc/ssl/certs path. As the volume is shared between the init container and guard container, when the init container updates the /etc/ssl/certs, the guard container will also have the updated ca-certificates.pem file which contains the proxy cert. This way the http client used to make the requests will be able to do successfully through proxy.

The proxy support is for azure-arc scenario where users will be setting up guard by themselves and also in future when arc switches to automating the guard setup for customers
