### PR TITLE
Feature - Azure - Enabling PoP Token verification

### DIFF
--- a/auth/providers/azure/options.go
+++ b/auth/providers/azure/options.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -34,6 +35,7 @@ const (
 	AKSAuthMode              = "aks"
 	OBOAuthMode              = "obo"
 	ClientCredentialAuthMode = "client-credential"
+	PassthroughAuthMode      = "passthrough"
 )
 
 type Options struct {
@@ -44,7 +46,11 @@ type Options struct {
 	UseGroupUID                              bool
 	AuthMode                                 string
 	AKSTokenURL                              string
+	EnablePOP                                bool
+	POPTokenHostname                         string
+	PoPTokenValidityDuration                 time.Duration
 	ResolveGroupMembershipOnlyOnOverageClaim bool
+	SkipGroupMembershipResolution            bool
 	VerifyClientID                           bool
 }
 
@@ -63,8 +69,12 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseGroupUID, "azure.use-group-uid", o.UseGroupUID, "Use group UID for authentication instead of group display name")
 	fs.StringVar(&o.AuthMode, "azure.auth-mode", "client-credential", "auth mode to call graph api, valid value is either aks, obo, or client-credential")
 	fs.StringVar(&o.AKSTokenURL, "azure.aks-token-url", "", "url to call for AKS OBO flow")
+	fs.StringVar(&o.POPTokenHostname, "azure.pop-hostname", "", "hostname used to run the pop hostname verification; 'u' claim")
+	fs.BoolVar(&o.EnablePOP, "azure.enable-pop", false, "Enabling pop token verification")
+	fs.DurationVar(&o.PoPTokenValidityDuration, "azure.pop-token-validity-duration", 15, "time duration for PoP token to be considered valid from creation time, default 15 min")
 	fs.BoolVar(&o.ResolveGroupMembershipOnlyOnOverageClaim, "azure.graph-call-on-overage-claim", o.ResolveGroupMembershipOnlyOnOverageClaim, "set to true to resolve group membership only when overage claim is present. setting to false will always call graph api to resolve group membership")
 	fs.BoolVar(&o.VerifyClientID, "azure.verify-clientID", o.VerifyClientID, "set to true to validate token's audience claim matches clientID")
+	fs.BoolVar(&o.SkipGroupMembershipResolution, "azure.skip-group-membership-resolution", false, "when set to true, this will bypass the getting group membership from graph api")
 }
 
 func (o *Options) Validate() []error {
@@ -74,11 +84,12 @@ func (o *Options) Validate() []error {
 	case AKSAuthMode:
 	case OBOAuthMode:
 	case ClientCredentialAuthMode:
+	case PassthroughAuthMode:
 	default:
-		errs = append(errs, errors.New("invalid azure.auth-mode. valid value is either aks, obo, or client-credential"))
+		errs = append(errs, errors.New("invalid azure.auth-mode. valid value is either aks, obo, client-credential or passthrough"))
 	}
 
-	if o.AuthMode != AKSAuthMode {
+	if o.AuthMode != AKSAuthMode && o.AuthMode != PassthroughAuthMode {
 		if o.ClientSecret == "" {
 			errs = append(errs, errors.New("azure.client-secret must be non-empty"))
 		}
@@ -91,6 +102,9 @@ func (o *Options) Validate() []error {
 	}
 	if o.VerifyClientID && o.ClientID == "" {
 		errs = append(errs, errors.New("azure.client-id must be non-empty when azure.verify-clientID is set"))
+	}
+	if o.EnablePOP && o.POPTokenHostname == "" {
+		errs = append(errs, errors.New("azure.pop-hostname must be non-empty when pop token is enabled"))
 	}
 	return errs
 }

--- a/auth/providers/azure/options_test.go
+++ b/auth/providers/azure/options_test.go
@@ -50,7 +50,7 @@ var (
 				o.AuthMode = empty
 				return o
 			},
-			errors.New("invalid azure.auth-mode. valid value is either aks, obo, or client-credential"),
+			errors.New("invalid azure.auth-mode. valid value is either aks, obo, client-credential or passtrough"),
 			true,
 		},
 		{
@@ -88,6 +88,16 @@ var (
 				return o
 			},
 			errors.New("azure.aks-token-url must be non-empty"),
+			false,
+		},
+		{
+			"azure.enable-pop is set without a hostname",
+			func(o Options) Options {
+				o.AuthMode = PassthroughAuthMode
+				o.EnablePOP = true
+				return o
+			},
+			errors.New("azure.pop-hostname must be non-empty when pop token are enabled"),
 			false,
 		},
 	}

--- a/auth/providers/azure/pop_tokenverifier.go
+++ b/auth/providers/azure/pop_tokenverifier.go
@@ -1,0 +1,212 @@
+/*
+Copyright The Guard Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/square/go-jose.v2/jwt"
+	"k8s.io/klog/v2"
+
+	"github.com/pkg/errors"
+)
+
+// PopTokenVerifier is validator for PoP tokens.
+type PoPTokenVerifier struct {
+	hostName                 string
+	PoPTokenValidityDuration time.Duration
+}
+
+func NewPoPVerifier(hostName string, popTokenValidityDuration time.Duration) *PoPTokenVerifier {
+	return &PoPTokenVerifier{
+		PoPTokenValidityDuration: popTokenValidityDuration,
+		hostName:                 hostName,
+	}
+}
+
+// Claims maintains token claims
+type Claims map[string]interface{}
+
+const (
+	//TypPoP signifies pop token
+	typPoP = "pop"
+	//TypJWT signifies AAD JWT token
+	typJWT = "JWT"
+	//AlgoRS256 signifies signing algorithm
+	algoRS256 = "RS256"
+)
+
+// Jwk maintains public key info
+type jwk struct {
+	e   string `json:"e"`
+	kty string `json:"kty"`
+	n   string `json:"n"`
+}
+
+// ValidatePopToken is validating the pop token
+// RFC : https://datatracker.ietf.org/doc/html/rfc7800
+func (p *PoPTokenVerifier) ValidatePopToken(token string) (string, error) {
+	data := strings.Split(token, ".")
+	if len(data) != 3 || data[0] == "" || data[1] == "" || data[2] == "" {
+		return "", errors.Errorf("PoP token invalid schema. Token length: %d", len(data))
+	}
+
+	ptoken, err := jwt.ParseSigned(token)
+	if err != nil {
+		return "", errors.Errorf("Could not parse PoP token. Error: %+v", err)
+	}
+	var claims Claims
+	err = ptoken.UnsafeClaimsWithoutVerification(&claims)
+	if err != nil {
+		return "", errors.Errorf("Cannot deserializes the claims from the PoP token. Error: %+v", err)
+	}
+
+	// This can never happens since the first 'if len(date) != 3' check if the header is present
+	if len(ptoken.Headers) <= 0 {
+		return "", errors.Errorf("No header found in PoP token")
+	}
+
+	if ptoken.Headers[0].KeyID == "" {
+		return "", errors.Errorf("No KeyID found in PoP token header")
+	}
+
+	if ptoken.Headers[0].Algorithm != algoRS256 {
+		return "", errors.Errorf("Wrong algorithm found in PoP token header, expected '%s' having '%s'", algoRS256, ptoken.Headers[0].Algorithm)
+	}
+
+	if typ, ok := ptoken.Headers[0].ExtraHeaders["typ"]; ok {
+		if tokenType, ok := typ.(string); ok {
+			if !strings.EqualFold(tokenType, typPoP) {
+				return "", errors.Errorf("Wrong typ. Expected '%s' having '%s'", typPoP, tokenType)
+			}
+		} else {
+			return "", errors.Errorf("Invalid token. 'typ' claim should be of string")
+		}
+	} else {
+		return "", errors.Errorf("Invalid token. 'typ' claim is missing")
+	}
+
+	// Verify expiry time
+	// This is useful to fail fast
+	now := time.Now()
+	var issuedTime time.Time
+	if ts, ok := claims["ts"]; ok {
+		convertTime(ts, &issuedTime)
+		expireat := issuedTime.Add(p.PoPTokenValidityDuration * time.Minute)
+		if expireat.Before(now) {
+			return "", errors.Errorf("Token is expired. Now: %v, Valid till: %v", now, expireat)
+		}
+	} else {
+		return "", errors.Errorf("Invalid token. 'ts' claim is missing")
+	}
+
+	// Verify host 'u' claim
+	if uc, ok := claims["u"]; ok {
+		if reqHostName, ok := uc.(string); ok {
+			if klog.V(10).Enabled() {
+				klog.V(10).Infoln("pop token validation running with hostName: %s. Request is coming for hostName: %s", p.hostName, reqHostName)
+			}
+			if !strings.EqualFold(reqHostName, p.hostName) {
+				return "", errors.Errorf("Invalid Pop token due to host mismatch. Expected: %q, received: %q", p.hostName, reqHostName)
+			}
+		} else {
+			return "", errors.Errorf("Invalid token. 'u' claim should be of string")
+		}
+	} else {
+		return "", errors.Errorf("Invalid token. 'u' claim is missing")
+	}
+
+	// "cnf" (confirmation) claim used to cryptographically confirm
+	// that the presenter has possession of that key.
+	// The value of the "cnf" claim is a JSON object and the
+	// members of that object identify the proof-of-possession key.
+	var cnf map[string]interface{}
+	if cnfclaim, ok := claims["cnf"]; ok {
+		if cnf, ok = cnfclaim.(map[string]interface{}); !ok {
+			return "", errors.Errorf("Invalid token. 'Cnf' claim is missing")
+		}
+	}
+
+	// When the key held by the presenter is an asymmetric private key, the
+	// "jwk" member is a JSON Web Key [JWK] representing the corresponding
+	// asymmetric public key.
+	var jwk jwk
+	if err := marshalGenericTo(cnf["jwk"], &jwk); err != nil {
+		return "", errors.Errorf("failed while parsing 'jwk' claim in PoP token : %v", err)
+	}
+
+	// Verify signing of PoP token
+	message := fmt.Sprintf("%s.%s", data[0], data[1])
+
+	signature, err := base64.RawURLEncoding.DecodeString(data[2])
+	if err != nil {
+		return "", errors.Errorf("Failed to base64 url decode message signature. Error: %+v", err)
+	}
+
+	n, err := base64.RawURLEncoding.DecodeString(jwk.n)
+	if err != nil {
+		return "", errors.Errorf("Failed to decode jwk.n .Error: %+v", err)
+	}
+	e, err := base64.RawURLEncoding.DecodeString(jwk.e)
+	if err != nil {
+		return "", errors.Errorf("Failed to decode jwk.e .Error: %+v", err)
+	}
+	z := new(big.Int)
+	z.SetBytes(n)
+
+	var buffer bytes.Buffer
+	buffer.WriteByte(0)
+	buffer.Write(e)
+	exponent := binary.BigEndian.Uint32(buffer.Bytes())
+	publicKey := &rsa.PublicKey{N: z, E: int(exponent)}
+
+	hasher := crypto.SHA256.New()
+	_, err = hasher.Write([]byte(message))
+	if err != nil {
+		return "", errors.Errorf("Failed to write message to hasher. Error:%+v", err)
+	}
+	err = rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, hasher.Sum(nil), signature)
+
+	if err != nil {
+		return "", errors.Errorf("RSA verify err: %+v", err)
+	}
+
+	return claims["at"].(string), nil
+}
+
+func convertTime(i interface{}, tm *time.Time) {
+	switch iat := i.(type) {
+	case float64:
+		*tm = time.Unix(int64(iat), 0)
+	case int64:
+		*tm = time.Unix(iat, 0)
+	case string:
+		v, _ := strconv.ParseInt(iat, 10, 64)
+		*tm = time.Unix(v, 0)
+	default:
+		*tm = time.Unix(0, 0)
+	}
+}

--- a/auth/providers/azure/pop_tokenverifier_test.go
+++ b/auth/providers/azure/pop_tokenverifier_test.go
@@ -1,0 +1,258 @@
+package azure
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/square/go-jose.v2"
+)
+
+const (
+	popAccessToken = `{ "aud": "client", "iss" : "kd", "exp" : "%d","cnf": {"kid":"%s","xms_ksl":"sw"} }`
+)
+
+type swPoPKey struct {
+	key    *rsa.PrivateKey
+	keyID  string
+	jwk    string
+	jwkTP  string
+	reqCnf string
+}
+
+func (swk *swPoPKey) Alg() string {
+	return "RS256"
+}
+
+func (swk *swPoPKey) Sign(payload []byte) ([]byte, error) {
+	return swk.key.Sign(rand.Reader, payload, crypto.SHA256)
+}
+
+func (swk *swPoPKey) KeyID() string {
+	return swk.keyID
+}
+
+func (swk *swPoPKey) Cnf() string {
+	return swk.reqCnf
+}
+
+func (swk *swPoPKey) Jwk() string {
+	return swk.jwk
+}
+
+func NewSWPoPKey() (*swPoPKey, error) {
+	pop := &swPoPKey{}
+	rsa, err := rsa.GenerateKey(rand.Reader, 1028)
+	if err != nil {
+		return nil, err
+	}
+	pop.key = rsa
+	pubKey := rsa.PublicKey
+	e := big.NewInt(int64(pubKey.E))
+	eB64 := base64.RawURLEncoding.EncodeToString(e.Bytes())
+	n := pubKey.N
+	nB64 := base64.RawURLEncoding.EncodeToString(n.Bytes())
+	jwk := fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s"}`, eB64, nB64)
+	jwkS256 := sha256.Sum256([]byte(jwk))
+	pop.jwkTP = base64.RawURLEncoding.EncodeToString(jwkS256[:])
+
+	reqCnfJSON := fmt.Sprintf(`{"kid":"%s","xms_ksl":"sw"}`, pop.jwkTP)
+	pop.reqCnf = base64.RawURLEncoding.EncodeToString([]byte(reqCnfJSON))
+	pop.keyID = pop.jwkTP
+	pop.jwk = fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s","alg":"RS256","kid":"%s"}`, eB64, nB64, pop.keyID)
+
+	return pop, nil
+}
+
+type swKey struct {
+	keyID  string
+	pKey   *rsa.PrivateKey
+	pubKey interface{}
+}
+
+func (swk *swKey) Alg() string {
+	return "RS256"
+}
+
+func (swk *swKey) KeyID() string {
+	return ""
+}
+
+func NewSwkKey() (*swKey, error) {
+	rsa, err := rsa.GenerateKey(rand.Reader, 1028)
+	if err != nil {
+		return nil, err
+	}
+	return &swKey{"", rsa, rsa.Public()}, nil
+}
+
+func (swk *swKey) GenerateToken(payload []byte) (string, error) {
+	pKey := &jose.JSONWebKey{Key: swk.pKey, Algorithm: swk.Alg(), KeyID: swk.KeyID()}
+
+	// create a Square.jose RSA signer, used to sign the JWT
+	var signerOpts = jose.SignerOptions{}
+	signerOpts.WithType("JWT")
+	rsaSigner, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: pKey}, &signerOpts)
+	if err != nil {
+		return "", err
+	}
+	jws, err := rsaSigner.Sign(payload)
+	if err != nil {
+		return "", err
+	}
+
+	token, err := jws.CompactSerialize()
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+const (
+	badTokenKey         = "badToken"
+	headerBadKeyID      = "headerBadKeyID"
+	headerBadAlgo       = "headerBadAlgo"
+	headerBadtyp        = "headerBadtyp"
+	headerBadtypType    = "headerBadtypType"
+	headerBadtypMissing = "headerBadtypMissing"
+	uClaimsMissing      = "uClaimsMissing"
+	uClaimsWrong        = "uClaimsWrong"
+	tsClaimsMissing     = "tsClaimsMissing"
+	cnfClaimsMissing    = "cnfClaimsMissing"
+	cnfJwkClaimsWrong   = "cnfJwkClaimsWrong"
+)
+
+func GeneratePoPToken(ts int64, hostName, kid string) (string, error) {
+	if strings.Contains(kid, badTokenKey) {
+		return kid, nil
+	}
+	popKey, err := NewSWPoPKey()
+	if err != nil {
+		return "", fmt.Errorf("Failed to generate Pop key. Error:%+v", err)
+	}
+
+	key, err := NewSwkKey()
+	if err != nil {
+		return "", fmt.Errorf("Failed to generate SF key. Error:%+v", err)
+	}
+
+	var cnf string = kid
+	if cnf == "" {
+		cnf = popKey.KeyID()
+	}
+
+	at, err := key.GenerateToken([]byte(fmt.Sprintf(popAccessToken, time.Now().Add(time.Minute*5).Unix(), cnf)))
+	if err != nil {
+		return "", fmt.Errorf("Error when generating token. Error:%+v", err)
+	}
+	var header, headerB64 string
+	nonce := uuid.New().String()
+	nonce = strings.Replace(nonce, "-", "", -1)
+	keyID := popKey.KeyID()
+	algo := popKey.Alg()
+	typ := "pop"
+	if kid == headerBadKeyID {
+		keyID = ""
+	}
+	if kid == headerBadAlgo {
+		algo = "wrong"
+	}
+	if kid == headerBadtyp {
+		typ = "wrong"
+	}
+	header = fmt.Sprintf(`{"typ":"%s","alg":"%s","kid":"%s"}`, typ, algo, keyID)
+
+	if kid == headerBadtypType {
+		wrongTyp := 1
+		header = fmt.Sprintf(`{"typ":"%d","alg":"%s","kid":"%s"}`, wrongTyp, algo, keyID)
+	}
+
+	if kid == headerBadtypMissing {
+		header = fmt.Sprintf(`{"alg":"%s","kid":"%s"}`, algo, keyID)
+	}
+
+	headerB64 = base64.RawURLEncoding.EncodeToString([]byte(header))
+
+	var payload, payloadB64 string
+	payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, ts, hostName, popKey.Jwk(), nonce)
+	if kid == tsClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "u": "%d", "cnf":{"jwk":%s}, "nonce":"%s"}`, at, 1, popKey.Jwk(), nonce)
+	}
+	if kid == uClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "cnf":{"jwk":%s}, "nonce":"%s"}`, at, ts, popKey.Jwk(), nonce)
+	}
+	if kid == cnfClaimsMissing {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s"`, at, ts, hostName)
+	}
+	if kid == cnfJwkClaimsWrong {
+		payload = fmt.Sprintf(`{ "at" : "%s", "ts" : %d, "u": "%s", "cnf":{}, "nonce":"%s"}`, at, ts, hostName, nonce)
+	}
+
+	payloadB64 = base64.RawURLEncoding.EncodeToString([]byte(payload))
+	h256 := sha256.Sum256([]byte(headerB64 + "." + payloadB64))
+	signature, err := popKey.Sign(h256[:])
+	if err != nil {
+		return "", fmt.Errorf("Error while signing pop key. Error:%+v", err)
+	}
+	signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+
+	finalToken := headerB64 + "." + payloadB64 + "." + signatureB64
+	return finalToken, nil
+}
+
+func TestPopTokenVerifier_Verify(t *testing.T) {
+	verifier := NewPoPVerifier("testHostname", 15*time.Minute)
+
+	validToken, _ := GeneratePoPToken(time.Now().Unix(), "testHostname", "")
+	_, err := verifier.ValidatePopToken(validToken)
+	assert.NoError(t, err)
+
+	invalidToken, _ := GeneratePoPToken(time.Now().Unix(), "", badTokenKey)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "PoP token invalid schema. Token length: 1")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "testHostname", fmt.Sprintf("%s.%s.%s", badTokenKey, badTokenKey, badTokenKey))
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Could not parse PoP token. Error: invalid character 'm' looking for beginning of value")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", headerBadKeyID)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "No KeyID found in PoP token header")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", headerBadAlgo)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Wrong algorithm found in PoP token header")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", headerBadtyp)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Wrong typ of token. Expected pop token")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", headerBadtypMissing)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. Typ claim missing")
+
+	expiredToken, _ := GeneratePoPToken(time.Now().Add(time.Minute*-20).Unix(), "", "")
+	_, err = verifier.ValidatePopToken(expiredToken)
+	assert.NotNilf(t, err, "PoP verification succeed.")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", tsClaimsMissing)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. ts claim missing")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "wrongHostnme", "")
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid Pop token. Host mismatch. Expected: testHostname, Req received: wrongHostnme")
+
+	invalidToken, _ = GeneratePoPToken(time.Now().Unix(), "", uClaimsMissing)
+	_, err = verifier.ValidatePopToken(invalidToken)
+	assert.EqualError(t, err, "Invalid token. u claim missing")
+}

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/goidentity.v1 v1.0.0 // indirect
 	gopkg.in/jcmturner/gokrb5.v4 v4.1.2
-	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/square/go-jose.v2 v2.6.0
 	k8s.io/api v0.21.1
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -835,6 +835,8 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2 h1:orlkJ3myw8CN1nVQHBFfloD+L3egixIa4FvUP6RosSA=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
+gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/vendor/gopkg.in/square/go-jose.v2/.gitignore
+++ b/vendor/gopkg.in/square/go-jose.v2/.gitignore
@@ -5,3 +5,4 @@
 *.pem
 *.cov
 jose-util/jose-util
+jose-util.t.err

--- a/vendor/gopkg.in/square/go-jose.v2/.travis.yml
+++ b/vendor/gopkg.in/square/go-jose.v2/.travis.yml
@@ -8,12 +8,9 @@ matrix:
     - go: tip
 
 go:
-- '1.5.x'
-- '1.6.x'
-- '1.7.x'
-- '1.8.x'
-- '1.9.x'
-- '1.10.x'
+- '1.14.x'
+- '1.15.x'
+- tip
 
 go_import_path: gopkg.in/square/go-jose.v2
 
@@ -29,6 +26,8 @@ before_install:
 - go get github.com/wadey/gocovmerge
 - go get github.com/mattn/goveralls
 - go get github.com/stretchr/testify/assert
+- go get github.com/stretchr/testify/require
+- go get github.com/google/go-cmp/cmp
 - go get golang.org/x/tools/cmd/cover || true
 - go get code.google.com/p/go.tools/cmd/cover || true
 - pip install cram --user
@@ -38,10 +37,9 @@ script:
 - go test ./cipher -v -covermode=count -coverprofile=cipher/profile.cov
 - go test ./jwt -v -covermode=count -coverprofile=jwt/profile.cov
 - go test ./json -v # no coverage for forked encoding/json package
-- cd jose-util && go build && PATH=$PWD:$PATH cram -v jose-util.t
+- cd jose-util && go build && PATH=$PWD:$PATH cram -v jose-util.t # cram tests jose-util
 - cd ..
 
 after_success:
 - gocovmerge *.cov */*.cov > merged.coverprofile
 - $HOME/gopath/bin/goveralls -coverprofile merged.coverprofile -service=travis-ci
-

--- a/vendor/gopkg.in/square/go-jose.v2/asymmetric.go
+++ b/vendor/gopkg.in/square/go-jose.v2/asymmetric.go
@@ -29,7 +29,7 @@ import (
 	"math/big"
 
 	"golang.org/x/crypto/ed25519"
-	"gopkg.in/square/go-jose.v2/cipher"
+	josecipher "gopkg.in/square/go-jose.v2/cipher"
 	"gopkg.in/square/go-jose.v2/json"
 )
 
@@ -288,7 +288,7 @@ func (ctx rsaDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm
 		out, err = rsa.SignPKCS1v15(RandReader, ctx.privateKey, hash, hashed)
 	case PS256, PS384, PS512:
 		out, err = rsa.SignPSS(RandReader, ctx.privateKey, hash, hashed, &rsa.PSSOptions{
-			SaltLength: rsa.PSSSaltLengthAuto,
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
 		})
 	}
 

--- a/vendor/gopkg.in/square/go-jose.v2/cipher/cbc_hmac.go
+++ b/vendor/gopkg.in/square/go-jose.v2/cipher/cbc_hmac.go
@@ -150,7 +150,7 @@ func (ctx *cbcAEAD) computeAuthTag(aad, nonce, ciphertext []byte) []byte {
 	return hmac.Sum(nil)[:ctx.authtagBytes]
 }
 
-// resize ensures the the given slice has a capacity of at least n bytes.
+// resize ensures that the given slice has a capacity of at least n bytes.
 // If the capacity of the slice is less than n, a new slice is allocated
 // and the existing data will be copied.
 func resize(in []byte, n uint64) (head, tail []byte) {

--- a/vendor/gopkg.in/square/go-jose.v2/crypter.go
+++ b/vendor/gopkg.in/square/go-jose.v2/crypter.go
@@ -141,6 +141,8 @@ func NewEncrypter(enc ContentEncryption, rcpt Recipient, opts *EncrypterOptions)
 		keyID, rawKey = encryptionKey.KeyID, encryptionKey.Key
 	case *JSONWebKey:
 		keyID, rawKey = encryptionKey.KeyID, encryptionKey.Key
+	case OpaqueKeyEncrypter:
+		keyID, rawKey = encryptionKey.KeyID(), encryptionKey
 	default:
 		rawKey = encryptionKey
 	}
@@ -214,6 +216,7 @@ func NewMultiEncrypter(enc ContentEncryption, rcpts []Recipient, opts *Encrypter
 
 	if opts != nil {
 		encrypter.compressionAlg = opts.Compression
+		encrypter.extraHeaders = opts.ExtraHeaders
 	}
 
 	for _, recipient := range rcpts {
@@ -267,9 +270,11 @@ func makeJWERecipient(alg KeyAlgorithm, encryptionKey interface{}) (recipientKey
 		recipient, err := makeJWERecipient(alg, encryptionKey.Key)
 		recipient.keyID = encryptionKey.KeyID
 		return recipient, err
-	default:
-		return recipientKeyInfo{}, ErrUnsupportedKeyType
 	}
+	if encrypter, ok := encryptionKey.(OpaqueKeyEncrypter); ok {
+		return newOpaqueKeyEncrypter(alg, encrypter)
+	}
+	return recipientKeyInfo{}, ErrUnsupportedKeyType
 }
 
 // newDecrypter creates an appropriate decrypter based on the key type
@@ -295,9 +300,11 @@ func newDecrypter(decryptionKey interface{}) (keyDecrypter, error) {
 		return newDecrypter(decryptionKey.Key)
 	case *JSONWebKey:
 		return newDecrypter(decryptionKey.Key)
-	default:
-		return nil, ErrUnsupportedKeyType
 	}
+	if okd, ok := decryptionKey.(OpaqueKeyDecrypter); ok {
+		return &opaqueKeyDecrypter{decrypter: okd}, nil
+	}
+	return nil, ErrUnsupportedKeyType
 }
 
 // Implementation of encrypt method producing a JWE object.

--- a/vendor/gopkg.in/square/go-jose.v2/encoding.go
+++ b/vendor/gopkg.in/square/go-jose.v2/encoding.go
@@ -23,12 +23,11 @@ import (
 	"encoding/binary"
 	"io"
 	"math/big"
-	"regexp"
+	"strings"
+	"unicode"
 
 	"gopkg.in/square/go-jose.v2/json"
 )
-
-var stripWhitespaceRegex = regexp.MustCompile("\\s")
 
 // Helper function to serialize known-good objects.
 // Precondition: value is not a nil pointer.
@@ -56,7 +55,14 @@ func mustSerializeJSON(value interface{}) []byte {
 
 // Strip all newlines and whitespace
 func stripWhitespace(data string) string {
-	return stripWhitespaceRegex.ReplaceAllString(data, "")
+	buf := strings.Builder{}
+	buf.Grow(len(data))
+	for _, r := range data {
+		if !unicode.IsSpace(r) {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
 }
 
 // Perform compression based on algorithm

--- a/vendor/gopkg.in/square/go-jose.v2/json/stream.go
+++ b/vendor/gopkg.in/square/go-jose.v2/json/stream.go
@@ -31,9 +31,14 @@ func NewDecoder(r io.Reader) *Decoder {
 	return &Decoder{r: r}
 }
 
+// Deprecated: Use `SetNumberType` instead
 // UseNumber causes the Decoder to unmarshal a number into an interface{} as a
 // Number instead of as a float64.
-func (dec *Decoder) UseNumber() { dec.d.useNumber = true }
+func (dec *Decoder) UseNumber() { dec.d.numberType = UnmarshalJSONNumber }
+
+// SetNumberType causes the Decoder to unmarshal a number into an interface{} as a
+// Number, float64 or int64 depending on `t` enum value.
+func (dec *Decoder) SetNumberType(t NumberUnmarshalType) { dec.d.numberType = t }
 
 // Decode reads the next JSON-encoded value from its
 // input and stores it in the value pointed to by v.

--- a/vendor/gopkg.in/square/go-jose.v2/jwk.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwk.go
@@ -17,15 +17,20 @@
 package jose
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -57,16 +62,31 @@ type rawJSONWebKey struct {
 	Dq *byteBuffer `json:"dq,omitempty"`
 	Qi *byteBuffer `json:"qi,omitempty"`
 	// Certificates
-	X5c []string `json:"x5c,omitempty"`
+	X5c       []string `json:"x5c,omitempty"`
+	X5u       *url.URL `json:"x5u,omitempty"`
+	X5tSHA1   string   `json:"x5t,omitempty"`
+	X5tSHA256 string   `json:"x5t#S256,omitempty"`
 }
 
 // JSONWebKey represents a public or private key in JWK format.
 type JSONWebKey struct {
-	Key          interface{}
+	// Cryptographic key, can be a symmetric or asymmetric key.
+	Key interface{}
+	// Key identifier, parsed from `kid` header.
+	KeyID string
+	// Key algorithm, parsed from `alg` header.
+	Algorithm string
+	// Key use, parsed from `use` header.
+	Use string
+
+	// X.509 certificate chain, parsed from `x5c` header.
 	Certificates []*x509.Certificate
-	KeyID        string
-	Algorithm    string
-	Use          string
+	// X.509 certificate URL, parsed from `x5u` header.
+	CertificatesURL *url.URL
+	// X.509 certificate thumbprint (SHA-1), parsed from `x5t` header.
+	CertificateThumbprintSHA1 []byte
+	// X.509 certificate thumbprint (SHA-256), parsed from `x5t#S256` header.
+	CertificateThumbprintSHA256 []byte
 }
 
 // MarshalJSON serializes the given key to its JSON representation.
@@ -105,6 +125,39 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 		raw.X5c = append(raw.X5c, base64.StdEncoding.EncodeToString(cert.Raw))
 	}
 
+	x5tSHA1Len := len(k.CertificateThumbprintSHA1)
+	x5tSHA256Len := len(k.CertificateThumbprintSHA256)
+	if x5tSHA1Len > 0 {
+		if x5tSHA1Len != sha1.Size {
+			return nil, fmt.Errorf("square/go-jose: invalid SHA-1 thumbprint (must be %d bytes, not %d)", sha1.Size, x5tSHA1Len)
+		}
+		raw.X5tSHA1 = base64.RawURLEncoding.EncodeToString(k.CertificateThumbprintSHA1)
+	}
+	if x5tSHA256Len > 0 {
+		if x5tSHA256Len != sha256.Size {
+			return nil, fmt.Errorf("square/go-jose: invalid SHA-256 thumbprint (must be %d bytes, not %d)", sha256.Size, x5tSHA256Len)
+		}
+		raw.X5tSHA256 = base64.RawURLEncoding.EncodeToString(k.CertificateThumbprintSHA256)
+	}
+
+	// If cert chain is attached (as opposed to being behind a URL), check the
+	// keys thumbprints to make sure they match what is expected. This is to
+	// ensure we don't accidentally produce a JWK with semantically inconsistent
+	// data in the headers.
+	if len(k.Certificates) > 0 {
+		expectedSHA1 := sha1.Sum(k.Certificates[0].Raw)
+		expectedSHA256 := sha256.Sum256(k.Certificates[0].Raw)
+
+		if len(k.CertificateThumbprintSHA1) > 0 && !bytes.Equal(k.CertificateThumbprintSHA1, expectedSHA1[:]) {
+			return nil, errors.New("square/go-jose: invalid SHA-1 thumbprint, does not match cert chain")
+		}
+		if len(k.CertificateThumbprintSHA256) > 0 && !bytes.Equal(k.CertificateThumbprintSHA256, expectedSHA256[:]) {
+			return nil, errors.New("square/go-jose: invalid or SHA-256 thumbprint, does not match cert chain")
+		}
+	}
+
+	raw.X5u = k.CertificatesURL
+
 	return json.Marshal(raw)
 }
 
@@ -116,28 +169,61 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		return err
 	}
 
+	certs, err := parseCertificateChain(raw.X5c)
+	if err != nil {
+		return fmt.Errorf("square/go-jose: failed to unmarshal x5c field: %s", err)
+	}
+
 	var key interface{}
+	var certPub interface{}
+	var keyPub interface{}
+
+	if len(certs) > 0 {
+		// We need to check that leaf public key matches the key embedded in this
+		// JWK, as required by the standard (see RFC 7517, Section 4.7). Otherwise
+		// the JWK parsed could be semantically invalid. Technically, should also
+		// check key usage fields and other extensions on the cert here, but the
+		// standard doesn't exactly explain how they're supposed to map from the
+		// JWK representation to the X.509 extensions.
+		certPub = certs[0].PublicKey
+	}
+
 	switch raw.Kty {
 	case "EC":
 		if raw.D != nil {
 			key, err = raw.ecPrivateKey()
+			if err == nil {
+				keyPub = key.(*ecdsa.PrivateKey).Public()
+			}
 		} else {
 			key, err = raw.ecPublicKey()
+			keyPub = key
 		}
 	case "RSA":
 		if raw.D != nil {
 			key, err = raw.rsaPrivateKey()
+			if err == nil {
+				keyPub = key.(*rsa.PrivateKey).Public()
+			}
 		} else {
 			key, err = raw.rsaPublicKey()
+			keyPub = key
 		}
 	case "oct":
+		if certPub != nil {
+			return errors.New("square/go-jose: invalid JWK, found 'oct' (symmetric) key with cert chain")
+		}
 		key, err = raw.symmetricKey()
 	case "OKP":
 		if raw.Crv == "Ed25519" && raw.X != nil {
 			if raw.D != nil {
 				key, err = raw.edPrivateKey()
+				if err == nil {
+					keyPub = key.(ed25519.PrivateKey).Public()
+				}
 			} else {
 				key, err = raw.edPublicKey()
+				keyPub = key
 			}
 		} else {
 			err = fmt.Errorf("square/go-jose: unknown curve %s'", raw.Crv)
@@ -146,12 +232,78 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		err = fmt.Errorf("square/go-jose: unknown json web key type '%s'", raw.Kty)
 	}
 
-	if err == nil {
-		*k = JSONWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use}
+	if err != nil {
+		return
+	}
 
-		k.Certificates, err = parseCertificateChain(raw.X5c)
+	if certPub != nil && keyPub != nil {
+		if !reflect.DeepEqual(certPub, keyPub) {
+			return errors.New("square/go-jose: invalid JWK, public keys in key and x5c fields do not match")
+		}
+	}
+
+	*k = JSONWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use, Certificates: certs}
+
+	k.CertificatesURL = raw.X5u
+
+	// x5t parameters are base64url-encoded SHA thumbprints
+	// See RFC 7517, Section 4.8, https://tools.ietf.org/html/rfc7517#section-4.8
+	x5tSHA1bytes, err := base64.RawURLEncoding.DecodeString(raw.X5tSHA1)
+	if err != nil {
+		return errors.New("square/go-jose: invalid JWK, x5t header has invalid encoding")
+	}
+
+	// RFC 7517, Section 4.8 is ambiguous as to whether the digest output should be byte or hex,
+	// for this reason, after base64 decoding, if the size is sha1.Size it's likely that the value is a byte encoded
+	// checksum so we skip this. Otherwise if the checksum was hex encoded we expect a 40 byte sized array so we'll
+	// try to hex decode it. When Marshalling this value we'll always use a base64 encoded version of byte format checksum.
+	if len(x5tSHA1bytes) == 2*sha1.Size {
+		hx, err := hex.DecodeString(string(x5tSHA1bytes))
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal x5c field: %s", err)
+			return fmt.Errorf("square/go-jose: invalid JWK, unable to hex decode x5t: %v", err)
+
+		}
+		x5tSHA1bytes = hx
+	}
+
+	k.CertificateThumbprintSHA1 = x5tSHA1bytes
+
+	x5tSHA256bytes, err := base64.RawURLEncoding.DecodeString(raw.X5tSHA256)
+	if err != nil {
+		return errors.New("square/go-jose: invalid JWK, x5t#S256 header has invalid encoding")
+	}
+
+	if len(x5tSHA256bytes) == 2*sha256.Size {
+		hx256, err := hex.DecodeString(string(x5tSHA256bytes))
+		if err != nil {
+			return fmt.Errorf("square/go-jose: invalid JWK, unable to hex decode x5t#S256: %v", err)
+		}
+		x5tSHA256bytes = hx256
+	}
+
+	k.CertificateThumbprintSHA256 = x5tSHA256bytes
+
+	x5tSHA1Len := len(k.CertificateThumbprintSHA1)
+	x5tSHA256Len := len(k.CertificateThumbprintSHA256)
+	if x5tSHA1Len > 0 && x5tSHA1Len != sha1.Size {
+		return errors.New("square/go-jose: invalid JWK, x5t header is of incorrect size")
+	}
+	if x5tSHA256Len > 0 && x5tSHA256Len != sha256.Size {
+		return errors.New("square/go-jose: invalid JWK, x5t#S256 header is of incorrect size")
+	}
+
+	// If certificate chain *and* thumbprints are set, verify correctness.
+	if len(k.Certificates) > 0 {
+		leaf := k.Certificates[0]
+		sha1sum := sha1.Sum(leaf.Raw)
+		sha256sum := sha256.Sum256(leaf.Raw)
+
+		if len(k.CertificateThumbprintSHA1) > 0 && !bytes.Equal(sha1sum[:], k.CertificateThumbprintSHA1) {
+			return errors.New("square/go-jose: invalid JWK, x5c thumbprint does not match x5t value")
+		}
+
+		if len(k.CertificateThumbprintSHA256) > 0 && !bytes.Equal(sha256sum[:], k.CertificateThumbprintSHA256) {
+			return errors.New("square/go-jose: invalid JWK, x5c thumbprint does not match x5t#S256 value")
 		}
 	}
 
@@ -180,7 +332,7 @@ func (s *JSONWebKeySet) Key(kid string) []JSONWebKey {
 
 const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`
 const ecThumbprintTemplate = `{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`
-const edThumbprintTemplate = `{"crv":"%s","kty":"OKP",x":"%s"}`
+const edThumbprintTemplate = `{"crv":"%s","kty":"OKP","x":"%s"}`
 
 func ecThumbprintInput(curve elliptic.Curve, x, y *big.Int) (string, error) {
 	coordLength := curveSize(curve)
@@ -230,7 +382,7 @@ func (k *JSONWebKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	case *rsa.PrivateKey:
 		input, err = rsaThumbprintInput(key.N, key.E)
 	case ed25519.PrivateKey:
-		input, err = edThumbprintInput(ed25519.PublicKey(key[0:32]))
+		input, err = edThumbprintInput(ed25519.PublicKey(key[32:]))
 	default:
 		return nil, fmt.Errorf("square/go-jose: unknown key type '%s'", reflect.TypeOf(key))
 	}
@@ -254,7 +406,7 @@ func (k *JSONWebKey) IsPublic() bool {
 	}
 }
 
-// Public creates JSONWebKey with corresponding publik key if JWK represents asymmetric private key.
+// Public creates JSONWebKey with corresponding public key if JWK represents asymmetric private key.
 func (k *JSONWebKey) Public() JSONWebKey {
 	if k.IsPublic() {
 		return *k
@@ -357,11 +509,11 @@ func (key rawJSONWebKey) ecPublicKey() (*ecdsa.PublicKey, error) {
 	// the curve specified in the "crv" parameter.
 	// https://tools.ietf.org/html/rfc7518#section-6.2.1.2
 	if curveSize(curve) != len(key.X.data) {
-		return nil, fmt.Errorf("square/go-jose: invalid EC private key, wrong length for x")
+		return nil, fmt.Errorf("square/go-jose: invalid EC public key, wrong length for x")
 	}
 
 	if curveSize(curve) != len(key.Y.data) {
-		return nil, fmt.Errorf("square/go-jose: invalid EC private key, wrong length for y")
+		return nil, fmt.Errorf("square/go-jose: invalid EC public key, wrong length for y")
 	}
 
 	x := key.X.bigInt()
@@ -421,8 +573,8 @@ func (key rawJSONWebKey) edPrivateKey() (ed25519.PrivateKey, error) {
 	}
 
 	privateKey := make([]byte, ed25519.PrivateKeySize)
-	copy(privateKey[0:32], key.X.bytes())
-	copy(privateKey[32:], key.D.bytes())
+	copy(privateKey[0:32], key.D.bytes())
+	copy(privateKey[32:], key.X.bytes())
 	rv := ed25519.PrivateKey(privateKey)
 	return rv, nil
 }
@@ -483,9 +635,9 @@ func (key rawJSONWebKey) rsaPrivateKey() (*rsa.PrivateKey, error) {
 }
 
 func fromEdPrivateKey(ed ed25519.PrivateKey) (*rawJSONWebKey, error) {
-	raw := fromEdPublicKey(ed25519.PublicKey(ed[0:32]))
+	raw := fromEdPublicKey(ed25519.PublicKey(ed[32:]))
 
-	raw.D = newBuffer(ed[32:])
+	raw.D = newBuffer(ed[0:32])
 	return raw, nil
 }
 

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/builder.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/builder.go
@@ -1,0 +1,334 @@
+/*-
+ * Copyright 2016 Zbigniew Mandziejewicz
+ * Copyright 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"bytes"
+	"reflect"
+
+	"gopkg.in/square/go-jose.v2/json"
+
+	"gopkg.in/square/go-jose.v2"
+)
+
+// Builder is a utility for making JSON Web Tokens. Calls can be chained, and
+// errors are accumulated until the final call to CompactSerialize/FullSerialize.
+type Builder interface {
+	// Claims encodes claims into JWE/JWS form. Multiple calls will merge claims
+	// into single JSON object. If you are passing private claims, make sure to set
+	// struct field tags to specify the name for the JSON key to be used when
+	// serializing.
+	Claims(i interface{}) Builder
+	// Token builds a JSONWebToken from provided data.
+	Token() (*JSONWebToken, error)
+	// FullSerialize serializes a token using the full serialization format.
+	FullSerialize() (string, error)
+	// CompactSerialize serializes a token using the compact serialization format.
+	CompactSerialize() (string, error)
+}
+
+// NestedBuilder is a utility for making Signed-Then-Encrypted JSON Web Tokens.
+// Calls can be chained, and errors are accumulated until final call to
+// CompactSerialize/FullSerialize.
+type NestedBuilder interface {
+	// Claims encodes claims into JWE/JWS form. Multiple calls will merge claims
+	// into single JSON object. If you are passing private claims, make sure to set
+	// struct field tags to specify the name for the JSON key to be used when
+	// serializing.
+	Claims(i interface{}) NestedBuilder
+	// Token builds a NestedJSONWebToken from provided data.
+	Token() (*NestedJSONWebToken, error)
+	// FullSerialize serializes a token using the full serialization format.
+	FullSerialize() (string, error)
+	// CompactSerialize serializes a token using the compact serialization format.
+	CompactSerialize() (string, error)
+}
+
+type builder struct {
+	payload map[string]interface{}
+	err     error
+}
+
+type signedBuilder struct {
+	builder
+	sig jose.Signer
+}
+
+type encryptedBuilder struct {
+	builder
+	enc jose.Encrypter
+}
+
+type nestedBuilder struct {
+	builder
+	sig jose.Signer
+	enc jose.Encrypter
+}
+
+// Signed creates builder for signed tokens.
+func Signed(sig jose.Signer) Builder {
+	return &signedBuilder{
+		sig: sig,
+	}
+}
+
+// Encrypted creates builder for encrypted tokens.
+func Encrypted(enc jose.Encrypter) Builder {
+	return &encryptedBuilder{
+		enc: enc,
+	}
+}
+
+// SignedAndEncrypted creates builder for signed-then-encrypted tokens.
+// ErrInvalidContentType will be returned if encrypter doesn't have JWT content type.
+func SignedAndEncrypted(sig jose.Signer, enc jose.Encrypter) NestedBuilder {
+	if contentType, _ := enc.Options().ExtraHeaders[jose.HeaderContentType].(jose.ContentType); contentType != "JWT" {
+		return &nestedBuilder{
+			builder: builder{
+				err: ErrInvalidContentType,
+			},
+		}
+	}
+	return &nestedBuilder{
+		sig: sig,
+		enc: enc,
+	}
+}
+
+func (b builder) claims(i interface{}) builder {
+	if b.err != nil {
+		return b
+	}
+
+	m, ok := i.(map[string]interface{})
+	switch {
+	case ok:
+		return b.merge(m)
+	case reflect.Indirect(reflect.ValueOf(i)).Kind() == reflect.Struct:
+		m, err := normalize(i)
+		if err != nil {
+			return builder{
+				err: err,
+			}
+		}
+		return b.merge(m)
+	default:
+		return builder{
+			err: ErrInvalidClaims,
+		}
+	}
+}
+
+func normalize(i interface{}) (map[string]interface{}, error) {
+	m := make(map[string]interface{})
+
+	raw, err := json.Marshal(i)
+	if err != nil {
+		return nil, err
+	}
+
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.SetNumberType(json.UnmarshalJSONNumber)
+
+	if err := d.Decode(&m); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (b *builder) merge(m map[string]interface{}) builder {
+	p := make(map[string]interface{})
+	for k, v := range b.payload {
+		p[k] = v
+	}
+	for k, v := range m {
+		p[k] = v
+	}
+
+	return builder{
+		payload: p,
+	}
+}
+
+func (b *builder) token(p func(interface{}) ([]byte, error), h []jose.Header) (*JSONWebToken, error) {
+	return &JSONWebToken{
+		payload: p,
+		Headers: h,
+	}, nil
+}
+
+func (b *signedBuilder) Claims(i interface{}) Builder {
+	return &signedBuilder{
+		builder: b.builder.claims(i),
+		sig:     b.sig,
+	}
+}
+
+func (b *signedBuilder) Token() (*JSONWebToken, error) {
+	sig, err := b.sign()
+	if err != nil {
+		return nil, err
+	}
+
+	h := make([]jose.Header, len(sig.Signatures))
+	for i, v := range sig.Signatures {
+		h[i] = v.Header
+	}
+
+	return b.builder.token(sig.Verify, h)
+}
+
+func (b *signedBuilder) CompactSerialize() (string, error) {
+	sig, err := b.sign()
+	if err != nil {
+		return "", err
+	}
+
+	return sig.CompactSerialize()
+}
+
+func (b *signedBuilder) FullSerialize() (string, error) {
+	sig, err := b.sign()
+	if err != nil {
+		return "", err
+	}
+
+	return sig.FullSerialize(), nil
+}
+
+func (b *signedBuilder) sign() (*jose.JSONWebSignature, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+
+	p, err := json.Marshal(b.payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.sig.Sign(p)
+}
+
+func (b *encryptedBuilder) Claims(i interface{}) Builder {
+	return &encryptedBuilder{
+		builder: b.builder.claims(i),
+		enc:     b.enc,
+	}
+}
+
+func (b *encryptedBuilder) CompactSerialize() (string, error) {
+	enc, err := b.encrypt()
+	if err != nil {
+		return "", err
+	}
+
+	return enc.CompactSerialize()
+}
+
+func (b *encryptedBuilder) FullSerialize() (string, error) {
+	enc, err := b.encrypt()
+	if err != nil {
+		return "", err
+	}
+
+	return enc.FullSerialize(), nil
+}
+
+func (b *encryptedBuilder) Token() (*JSONWebToken, error) {
+	enc, err := b.encrypt()
+	if err != nil {
+		return nil, err
+	}
+
+	return b.builder.token(enc.Decrypt, []jose.Header{enc.Header})
+}
+
+func (b *encryptedBuilder) encrypt() (*jose.JSONWebEncryption, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+
+	p, err := json.Marshal(b.payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.enc.Encrypt(p)
+}
+
+func (b *nestedBuilder) Claims(i interface{}) NestedBuilder {
+	return &nestedBuilder{
+		builder: b.builder.claims(i),
+		sig:     b.sig,
+		enc:     b.enc,
+	}
+}
+
+func (b *nestedBuilder) Token() (*NestedJSONWebToken, error) {
+	enc, err := b.signAndEncrypt()
+	if err != nil {
+		return nil, err
+	}
+
+	return &NestedJSONWebToken{
+		enc:     enc,
+		Headers: []jose.Header{enc.Header},
+	}, nil
+}
+
+func (b *nestedBuilder) CompactSerialize() (string, error) {
+	enc, err := b.signAndEncrypt()
+	if err != nil {
+		return "", err
+	}
+
+	return enc.CompactSerialize()
+}
+
+func (b *nestedBuilder) FullSerialize() (string, error) {
+	enc, err := b.signAndEncrypt()
+	if err != nil {
+		return "", err
+	}
+
+	return enc.FullSerialize(), nil
+}
+
+func (b *nestedBuilder) signAndEncrypt() (*jose.JSONWebEncryption, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+
+	p, err := json.Marshal(b.payload)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := b.sig.Sign(p)
+	if err != nil {
+		return nil, err
+	}
+
+	p2, err := sig.CompactSerialize()
+	if err != nil {
+		return nil, err
+	}
+
+	return b.enc.Encrypt([]byte(p2))
+}

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/claims.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/claims.go
@@ -1,0 +1,121 @@
+/*-
+ * Copyright 2016 Zbigniew Mandziejewicz
+ * Copyright 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"strconv"
+	"time"
+
+	"gopkg.in/square/go-jose.v2/json"
+)
+
+// Claims represents public claim values (as specified in RFC 7519).
+type Claims struct {
+	Issuer    string       `json:"iss,omitempty"`
+	Subject   string       `json:"sub,omitempty"`
+	Audience  Audience     `json:"aud,omitempty"`
+	Expiry    *NumericDate `json:"exp,omitempty"`
+	NotBefore *NumericDate `json:"nbf,omitempty"`
+	IssuedAt  *NumericDate `json:"iat,omitempty"`
+	ID        string       `json:"jti,omitempty"`
+}
+
+// NumericDate represents date and time as the number of seconds since the
+// epoch, ignoring leap seconds. Non-integer values can be represented
+// in the serialized format, but we round to the nearest second.
+// See RFC7519 Section 2: https://tools.ietf.org/html/rfc7519#section-2
+type NumericDate int64
+
+// NewNumericDate constructs NumericDate from time.Time value.
+func NewNumericDate(t time.Time) *NumericDate {
+	if t.IsZero() {
+		return nil
+	}
+
+	// While RFC 7519 technically states that NumericDate values may be
+	// non-integer values, we don't bother serializing timestamps in
+	// claims with sub-second accurancy and just round to the nearest
+	// second instead. Not convined sub-second accuracy is useful here.
+	out := NumericDate(t.Unix())
+	return &out
+}
+
+// MarshalJSON serializes the given NumericDate into its JSON representation.
+func (n NumericDate) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatInt(int64(n), 10)), nil
+}
+
+// UnmarshalJSON reads a date from its JSON representation.
+func (n *NumericDate) UnmarshalJSON(b []byte) error {
+	s := string(b)
+
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return ErrUnmarshalNumericDate
+	}
+
+	*n = NumericDate(f)
+	return nil
+}
+
+// Time returns time.Time representation of NumericDate.
+func (n *NumericDate) Time() time.Time {
+	if n == nil {
+		return time.Time{}
+	}
+	return time.Unix(int64(*n), 0)
+}
+
+// Audience represents the recipients that the token is intended for.
+type Audience []string
+
+// UnmarshalJSON reads an audience from its JSON representation.
+func (s *Audience) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	switch v := v.(type) {
+	case string:
+		*s = []string{v}
+	case []interface{}:
+		a := make([]string, len(v))
+		for i, e := range v {
+			s, ok := e.(string)
+			if !ok {
+				return ErrUnmarshalAudience
+			}
+			a[i] = s
+		}
+		*s = a
+	default:
+		return ErrUnmarshalAudience
+	}
+
+	return nil
+}
+
+func (s Audience) Contains(v string) bool {
+	for _, a := range s {
+		if a == v {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/doc.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/doc.go
@@ -1,0 +1,22 @@
+/*-
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+
+Package jwt provides an implementation of the JSON Web Token standard.
+
+*/
+package jwt

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/errors.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/errors.go
@@ -1,0 +1,53 @@
+/*-
+ * Copyright 2016 Zbigniew Mandziejewicz
+ * Copyright 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import "errors"
+
+// ErrUnmarshalAudience indicates that aud claim could not be unmarshalled.
+var ErrUnmarshalAudience = errors.New("square/go-jose/jwt: expected string or array value to unmarshal to Audience")
+
+// ErrUnmarshalNumericDate indicates that JWT NumericDate could not be unmarshalled.
+var ErrUnmarshalNumericDate = errors.New("square/go-jose/jwt: expected number value to unmarshal NumericDate")
+
+// ErrInvalidClaims indicates that given claims have invalid type.
+var ErrInvalidClaims = errors.New("square/go-jose/jwt: expected claims to be value convertible into JSON object")
+
+// ErrInvalidIssuer indicates invalid iss claim.
+var ErrInvalidIssuer = errors.New("square/go-jose/jwt: validation failed, invalid issuer claim (iss)")
+
+// ErrInvalidSubject indicates invalid sub claim.
+var ErrInvalidSubject = errors.New("square/go-jose/jwt: validation failed, invalid subject claim (sub)")
+
+// ErrInvalidAudience indicated invalid aud claim.
+var ErrInvalidAudience = errors.New("square/go-jose/jwt: validation failed, invalid audience claim (aud)")
+
+// ErrInvalidID indicates invalid jti claim.
+var ErrInvalidID = errors.New("square/go-jose/jwt: validation failed, invalid ID claim (jti)")
+
+// ErrNotValidYet indicates that token is used before time indicated in nbf claim.
+var ErrNotValidYet = errors.New("square/go-jose/jwt: validation failed, token not valid yet (nbf)")
+
+// ErrExpired indicates that token is used after expiry time indicated in exp claim.
+var ErrExpired = errors.New("square/go-jose/jwt: validation failed, token is expired (exp)")
+
+// ErrIssuedInTheFuture indicates that the iat field is in the future.
+var ErrIssuedInTheFuture = errors.New("square/go-jose/jwt: validation field, token issued in the future (iat)")
+
+// ErrInvalidContentType indicates that token requires JWT cty header.
+var ErrInvalidContentType = errors.New("square/go-jose/jwt: expected content type to be JWT (cty header)")

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/jwt.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/jwt.go
@@ -1,0 +1,169 @@
+/*-
+ * Copyright 2016 Zbigniew Mandziejewicz
+ * Copyright 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import (
+	"fmt"
+	"strings"
+
+	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/json"
+)
+
+// JSONWebToken represents a JSON Web Token (as specified in RFC7519).
+type JSONWebToken struct {
+	payload           func(k interface{}) ([]byte, error)
+	unverifiedPayload func() []byte
+	Headers           []jose.Header
+}
+
+type NestedJSONWebToken struct {
+	enc     *jose.JSONWebEncryption
+	Headers []jose.Header
+}
+
+// Claims deserializes a JSONWebToken into dest using the provided key.
+func (t *JSONWebToken) Claims(key interface{}, dest ...interface{}) error {
+	payloadKey := tryJWKS(t.Headers, key)
+
+	b, err := t.payload(payloadKey)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range dest {
+		if err := json.Unmarshal(b, d); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UnsafeClaimsWithoutVerification deserializes the claims of a
+// JSONWebToken into the dests. For signed JWTs, the claims are not
+// verified. This function won't work for encrypted JWTs.
+func (t *JSONWebToken) UnsafeClaimsWithoutVerification(dest ...interface{}) error {
+	if t.unverifiedPayload == nil {
+		return fmt.Errorf("square/go-jose: Cannot get unverified claims")
+	}
+	claims := t.unverifiedPayload()
+	for _, d := range dest {
+		if err := json.Unmarshal(claims, d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *NestedJSONWebToken) Decrypt(decryptionKey interface{}) (*JSONWebToken, error) {
+	key := tryJWKS(t.Headers, decryptionKey)
+
+	b, err := t.enc.Decrypt(key)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := ParseSigned(string(b))
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
+}
+
+// ParseSigned parses token from JWS form.
+func ParseSigned(s string) (*JSONWebToken, error) {
+	sig, err := jose.ParseSigned(s)
+	if err != nil {
+		return nil, err
+	}
+	headers := make([]jose.Header, len(sig.Signatures))
+	for i, signature := range sig.Signatures {
+		headers[i] = signature.Header
+	}
+
+	return &JSONWebToken{
+		payload:           sig.Verify,
+		unverifiedPayload: sig.UnsafePayloadWithoutVerification,
+		Headers:           headers,
+	}, nil
+}
+
+// ParseEncrypted parses token from JWE form.
+func ParseEncrypted(s string) (*JSONWebToken, error) {
+	enc, err := jose.ParseEncrypted(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &JSONWebToken{
+		payload: enc.Decrypt,
+		Headers: []jose.Header{enc.Header},
+	}, nil
+}
+
+// ParseSignedAndEncrypted parses signed-then-encrypted token from JWE form.
+func ParseSignedAndEncrypted(s string) (*NestedJSONWebToken, error) {
+	enc, err := jose.ParseEncrypted(s)
+	if err != nil {
+		return nil, err
+	}
+
+	contentType, _ := enc.Header.ExtraHeaders[jose.HeaderContentType].(string)
+	if strings.ToUpper(contentType) != "JWT" {
+		return nil, ErrInvalidContentType
+	}
+
+	return &NestedJSONWebToken{
+		enc:     enc,
+		Headers: []jose.Header{enc.Header},
+	}, nil
+}
+
+func tryJWKS(headers []jose.Header, key interface{}) interface{} {
+	var jwks jose.JSONWebKeySet
+
+	switch jwksType := key.(type) {
+	case *jose.JSONWebKeySet:
+		jwks = *jwksType
+	case jose.JSONWebKeySet:
+		jwks = jwksType
+	default:
+		return key
+	}
+
+	var kid string
+	for _, header := range headers {
+		if header.KeyID != "" {
+			kid = header.KeyID
+			break
+		}
+	}
+
+	if kid == "" {
+		return key
+	}
+
+	keys := jwks.Key(kid)
+	if len(keys) == 0 {
+		return key
+	}
+
+	return keys[0].Key
+}

--- a/vendor/gopkg.in/square/go-jose.v2/jwt/validation.go
+++ b/vendor/gopkg.in/square/go-jose.v2/jwt/validation.go
@@ -1,0 +1,114 @@
+/*-
+ * Copyright 2016 Zbigniew Mandziejewicz
+ * Copyright 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+import "time"
+
+const (
+	// DefaultLeeway defines the default leeway for matching NotBefore/Expiry claims.
+	DefaultLeeway = 1.0 * time.Minute
+)
+
+// Expected defines values used for protected claims validation.
+// If field has zero value then validation is skipped.
+type Expected struct {
+	// Issuer matches the "iss" claim exactly.
+	Issuer string
+	// Subject matches the "sub" claim exactly.
+	Subject string
+	// Audience matches the values in "aud" claim, regardless of their order.
+	Audience Audience
+	// ID matches the "jti" claim exactly.
+	ID string
+	// Time matches the "exp", "nbf" and "iat" claims with leeway.
+	Time time.Time
+}
+
+// WithTime copies expectations with new time.
+func (e Expected) WithTime(t time.Time) Expected {
+	e.Time = t
+	return e
+}
+
+// Validate checks claims in a token against expected values.
+// A default leeway value of one minute is used to compare time values.
+//
+// The default leeway will cause the token to be deemed valid until one
+// minute after the expiration time. If you're a server application that
+// wants to give an extra minute to client tokens, use this
+// function. If you're a client application wondering if the server
+// will accept your token, use ValidateWithLeeway with a leeway <=0,
+// otherwise this function might make you think a token is valid when
+// it is not.
+func (c Claims) Validate(e Expected) error {
+	return c.ValidateWithLeeway(e, DefaultLeeway)
+}
+
+// ValidateWithLeeway checks claims in a token against expected values. A
+// custom leeway may be specified for comparing time values. You may pass a
+// zero value to check time values with no leeway, but you should not that
+// numeric date values are rounded to the nearest second and sub-second
+// precision is not supported.
+//
+// The leeway gives some extra time to the token from the server's
+// point of view. That is, if the token is expired, ValidateWithLeeway
+// will still accept the token for 'leeway' amount of time. This fails
+// if you're using this function to check if a server will accept your
+// token, because it will think the token is valid even after it
+// expires. So if you're a client validating if the token is valid to
+// be submitted to a server, use leeway <=0, if you're a server
+// validation a token, use leeway >=0.
+func (c Claims) ValidateWithLeeway(e Expected, leeway time.Duration) error {
+	if e.Issuer != "" && e.Issuer != c.Issuer {
+		return ErrInvalidIssuer
+	}
+
+	if e.Subject != "" && e.Subject != c.Subject {
+		return ErrInvalidSubject
+	}
+
+	if e.ID != "" && e.ID != c.ID {
+		return ErrInvalidID
+	}
+
+	if len(e.Audience) != 0 {
+		for _, v := range e.Audience {
+			if !c.Audience.Contains(v) {
+				return ErrInvalidAudience
+			}
+		}
+	}
+
+	if !e.Time.IsZero() {
+		if c.NotBefore != nil && e.Time.Add(leeway).Before(c.NotBefore.Time()) {
+			return ErrNotValidYet
+		}
+
+		if c.Expiry != nil && e.Time.Add(-leeway).After(c.Expiry.Time()) {
+			return ErrExpired
+		}
+
+		// IssuedAt is optional but cannot be in the future. This is not required by the RFC, but
+		// something is misconfigured if this happens and we should not trust it.
+		if c.IssuedAt != nil && e.Time.Add(leeway).Before(c.IssuedAt.Time()) {
+			return ErrIssuedInTheFuture
+		}
+	}
+
+	return nil
+}

--- a/vendor/gopkg.in/square/go-jose.v2/opaque.go
+++ b/vendor/gopkg.in/square/go-jose.v2/opaque.go
@@ -17,7 +17,7 @@
 package jose
 
 // OpaqueSigner is an interface that supports signing payloads with opaque
-// private key(s). Private key operations preformed by implementors may, for
+// private key(s). Private key operations performed by implementers may, for
 // example, occur in a hardware module. An OpaqueSigner may rotate signing keys
 // transparently to the user of this interface.
 type OpaqueSigner interface {
@@ -80,4 +80,65 @@ type opaqueVerifier struct {
 
 func (o *opaqueVerifier) verifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
 	return o.verifier.VerifyPayload(payload, signature, alg)
+}
+
+// OpaqueKeyEncrypter is an interface that supports encrypting keys with an opaque key.
+type OpaqueKeyEncrypter interface {
+	// KeyID returns the kid
+	KeyID() string
+	// Algs returns a list of supported key encryption algorithms.
+	Algs() []KeyAlgorithm
+	// encryptKey encrypts the CEK using the given algorithm.
+	encryptKey(cek []byte, alg KeyAlgorithm) (recipientInfo, error)
+}
+
+type opaqueKeyEncrypter struct {
+	encrypter OpaqueKeyEncrypter
+}
+
+func newOpaqueKeyEncrypter(alg KeyAlgorithm, encrypter OpaqueKeyEncrypter) (recipientKeyInfo, error) {
+	var algSupported bool
+	for _, salg := range encrypter.Algs() {
+		if alg == salg {
+			algSupported = true
+			break
+		}
+	}
+	if !algSupported {
+		return recipientKeyInfo{}, ErrUnsupportedAlgorithm
+	}
+
+	return recipientKeyInfo{
+		keyID:  encrypter.KeyID(),
+		keyAlg: alg,
+		keyEncrypter: &opaqueKeyEncrypter{
+			encrypter: encrypter,
+		},
+	}, nil
+}
+
+func (oke *opaqueKeyEncrypter) encryptKey(cek []byte, alg KeyAlgorithm) (recipientInfo, error) {
+	return oke.encrypter.encryptKey(cek, alg)
+}
+
+//OpaqueKeyDecrypter is an interface that supports decrypting keys with an opaque key.
+type OpaqueKeyDecrypter interface {
+	DecryptKey(encryptedKey []byte, header Header) ([]byte, error)
+}
+
+type opaqueKeyDecrypter struct {
+	decrypter OpaqueKeyDecrypter
+}
+
+func (okd *opaqueKeyDecrypter) decryptKey(headers rawHeader, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
+	mergedHeaders := rawHeader{}
+	mergedHeaders.merge(&headers)
+	mergedHeaders.merge(recipient.header)
+
+	header, err := mergedHeaders.sanitized()
+	if err != nil {
+		return nil, err
+	}
+
+	return okd.decrypter.DecryptKey(recipient.encryptedKey, header)
 }

--- a/vendor/gopkg.in/square/go-jose.v2/shared.go
+++ b/vendor/gopkg.in/square/go-jose.v2/shared.go
@@ -153,11 +153,17 @@ const (
 	headerJWK   = "jwk"   // *JSONWebKey
 	headerKeyID = "kid"   // string
 	headerNonce = "nonce" // string
+	headerB64   = "b64"   // bool
 
 	headerP2C = "p2c" // *byteBuffer (int)
 	headerP2S = "p2s" // *byteBuffer ([]byte)
 
 )
+
+// supportedCritical is the set of supported extensions that are understood and processed.
+var supportedCritical = map[string]bool{
+	headerB64: true,
+}
 
 // rawHeader represents the JOSE header for JWE/JWS objects (used for parsing).
 //
@@ -177,7 +183,7 @@ type Header struct {
 	// Unverified certificate chain parsed from x5c header.
 	certificates []*x509.Certificate
 
-	// Any headers not recognised above get unmarshaled
+	// Any headers not recognised above get unmarshalled
 	// from JSON in a generic manner and placed in this map.
 	ExtraHeaders map[HeaderKey]interface{}
 }
@@ -289,12 +295,12 @@ func (parsed rawHeader) getAPV() (*byteBuffer, error) {
 	return parsed.getByteBuffer(headerAPV)
 }
 
-// getIV extracts parsed "iv" frpom the raw JSON.
+// getIV extracts parsed "iv" from the raw JSON.
 func (parsed rawHeader) getIV() (*byteBuffer, error) {
 	return parsed.getByteBuffer(headerIV)
 }
 
-// getTag extracts parsed "tag" frpom the raw JSON.
+// getTag extracts parsed "tag" from the raw JSON.
 func (parsed rawHeader) getTag() (*byteBuffer, error) {
 	return parsed.getByteBuffer(headerTag)
 }
@@ -347,6 +353,21 @@ func (parsed rawHeader) getP2C() (int, error) {
 // getS2S extracts parsed "p2s" from the raw JSON.
 func (parsed rawHeader) getP2S() (*byteBuffer, error) {
 	return parsed.getByteBuffer(headerP2S)
+}
+
+// getB64 extracts parsed "b64" from the raw JSON, defaulting to true.
+func (parsed rawHeader) getB64() (bool, error) {
+	v := parsed[headerB64]
+	if v == nil {
+		return true, nil
+	}
+
+	var b64 bool
+	err := json.Unmarshal(*v, &b64)
+	if err != nil {
+		return true, err
+	}
+	return b64, nil
 }
 
 // sanitized produces a cleaned-up header object from the raw JSON.

--- a/vendor/gopkg.in/square/go-jose.v2/signing.go
+++ b/vendor/gopkg.in/square/go-jose.v2/signing.go
@@ -17,6 +17,7 @@
 package jose
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/base64"
@@ -75,6 +76,27 @@ func (so *SignerOptions) WithContentType(contentType ContentType) *SignerOptions
 // WithType adds a type ("typ") header and returns the updated SignerOptions.
 func (so *SignerOptions) WithType(typ ContentType) *SignerOptions {
 	return so.WithHeader(HeaderType, typ)
+}
+
+// WithCritical adds the given names to the critical ("crit") header and returns
+// the updated SignerOptions.
+func (so *SignerOptions) WithCritical(names ...string) *SignerOptions {
+	if so.ExtraHeaders[headerCritical] == nil {
+		so.WithHeader(headerCritical, make([]string, 0, len(names)))
+	}
+	crit := so.ExtraHeaders[headerCritical].([]string)
+	so.ExtraHeaders[headerCritical] = append(crit, names...)
+	return so
+}
+
+// WithBase64 adds a base64url-encode payload ("b64") header and returns the updated
+// SignerOptions. When the "b64" value is "false", the payload is not base64 encoded.
+func (so *SignerOptions) WithBase64(b64 bool) *SignerOptions {
+	if !b64 {
+		so.WithHeader(headerB64, b64)
+		so.WithCritical(headerB64)
+	}
+	return so
 }
 
 type payloadSigner interface {
@@ -233,7 +255,10 @@ func (ctx *genericSigner) Sign(payload []byte) (*JSONWebSignature, error) {
 			if ctx.embedJWK {
 				protected[headerJWK] = recipient.publicKey()
 			} else {
-				protected[headerKeyID] = recipient.publicKey().KeyID
+				keyID := recipient.publicKey().KeyID
+				if keyID != "" {
+					protected[headerKeyID] = keyID
+				}
 			}
 		}
 
@@ -250,12 +275,26 @@ func (ctx *genericSigner) Sign(payload []byte) (*JSONWebSignature, error) {
 		}
 
 		serializedProtected := mustSerializeJSON(protected)
+		needsBase64 := true
 
-		input := []byte(fmt.Sprintf("%s.%s",
-			base64.RawURLEncoding.EncodeToString(serializedProtected),
-			base64.RawURLEncoding.EncodeToString(payload)))
+		if b64, ok := protected[headerB64]; ok {
+			if needsBase64, ok = b64.(bool); !ok {
+				return nil, errors.New("square/go-jose: Invalid b64 header parameter")
+			}
+		}
 
-		signatureInfo, err := recipient.signer.signPayload(input, recipient.sigAlg)
+		var input bytes.Buffer
+
+		input.WriteString(base64.RawURLEncoding.EncodeToString(serializedProtected))
+		input.WriteByte('.')
+
+		if needsBase64 {
+			input.WriteString(base64.RawURLEncoding.EncodeToString(payload))
+		} else {
+			input.Write(payload)
+		}
+
+		signatureInfo, err := recipient.signer.signPayload(input.Bytes(), recipient.sigAlg)
 		if err != nil {
 			return nil, err
 		}
@@ -324,12 +363,18 @@ func (obj JSONWebSignature) DetachedVerify(payload []byte, verificationKey inter
 	if err != nil {
 		return err
 	}
-	if len(critical) > 0 {
-		// Unsupported crit header
+
+	for _, name := range critical {
+		if !supportedCritical[name] {
+			return ErrCryptoFailure
+		}
+	}
+
+	input, err := obj.computeAuthData(payload, &signature)
+	if err != nil {
 		return ErrCryptoFailure
 	}
 
-	input := obj.computeAuthData(payload, &signature)
 	alg := headers.getSignatureAlgorithm()
 	err = verifier.verifyPayload(input, signature.Signature, alg)
 	if err == nil {
@@ -366,18 +411,25 @@ func (obj JSONWebSignature) DetachedVerifyMulti(payload []byte, verificationKey 
 		return -1, Signature{}, err
 	}
 
+outer:
 	for i, signature := range obj.Signatures {
 		headers := signature.mergedHeaders()
 		critical, err := headers.getCritical()
 		if err != nil {
 			continue
 		}
-		if len(critical) > 0 {
-			// Unsupported crit header
+
+		for _, name := range critical {
+			if !supportedCritical[name] {
+				continue outer
+			}
+		}
+
+		input, err := obj.computeAuthData(payload, &signature)
+		if err != nil {
 			continue
 		}
 
-		input := obj.computeAuthData(payload, &signature)
 		alg := headers.getSignatureAlgorithm()
 		err = verifier.verifyPayload(input, signature.Signature, alg)
 		if err == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -546,10 +546,11 @@ gopkg.in/jcmturner/gokrb5.v4/ndr
 gopkg.in/jcmturner/gokrb5.v4/pac
 gopkg.in/jcmturner/gokrb5.v4/service
 gopkg.in/jcmturner/gokrb5.v4/types
-# gopkg.in/square/go-jose.v2 v2.2.2
+# gopkg.in/square/go-jose.v2 v2.6.0
 gopkg.in/square/go-jose.v2
 gopkg.in/square/go-jose.v2/cipher
 gopkg.in/square/go-jose.v2/json
+gopkg.in/square/go-jose.v2/jwt
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
This PR allows any Azure Auth provider to leverage AAD based authentication using tokens with [proof of possession (PoP)](https://datatracker.ietf.org/doc/html/rfc7800).

Introducing :
- New flag `azure.enable-pop` to either activate or not this verification
- New flag `azure.pop-hostname` used by PoP to validate the `u` claim been passed
- New flag `azure.pop-token-validity-duration` to set a TTL duration for the PoP token been passed
- New flag `azure.skip-group-membership-resolution` used to bypass the group membership resolution logic
- New `PassthroughAuthMode` used when we don't want to run any extra validation against GRAPH such as refreshing or get a new token. This scenario is mainly used by Azure Arc today since `AKSAuthMode` `OBOAuthMode` `ClientCredentialAuthMode` cannot been used
- New `PoPTokenVerifier` Struct used to verify the PoP token structure. As today this is non official and custom code but following up with AAD Team to see how and when this verification will be official and been supported in GO-MSAL ?
- Adding UTs for each new components
 