### PR TITLE
enable fleet hub RBAC on fleets/managedNamespaces

### DIFF
--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -450,7 +450,7 @@ func (a *AccessInfo) CheckAccess(request *authzv1.SubjectAccessReviewSpec) (*aut
 	// Fallback to managed namespace check
 	managedNamespaceExists, managedNamespacePath := getManagedNameSpaceScope(request)
 	if a.useManagedNamespaceResourceScopeFormat &&
-		a.clusterType == managedClusters &&
+		(a.clusterType == managedClusters || a.clusterType == fleets) &&
 		managedNamespaceExists {
 		klog.V(7).Infof("Falling back to checking managed namespace scope for user %s", checkAccessUsername)
 		// Build managed namespace URL


### PR DESCRIPTION
Enable evaluation of data actions like `Microsoft.ContainerService/fleets/namespaces/read` against `Microsoft.ContainerService/fleets/managedNamespaces` subresources for Fleet hub access.

(This is required for Fleet managed namespace enablement in addition to the work already done in #420 , which enables evaluation of data actions like `Microsoft.ContainerService/fleets/members/namespaces/read` against `Microsoft.ContainerService/fleets/managedNamespaces` subresources for Fleet **member** access.)
