### PR TITLE
docs: fix linting issues and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Twitter](https://img.shields.io/twitter/follow/kubeguard.svg?style=social&logo=twitter&label=Follow)](https://twitter.com/intent/follow?screen_name=KubeGuard)
 
 # Guard
-Guard by AppsCode is a [Kubernetes Webhook Authentication](https://kubernetes.io/docs/admin/authentication/#webhook-token-authentication) server. Using guard, you can log into your Kubernetes cluster using various auth providers. Guard also configures groups of authenticated user appropriately. This allows cluster administrator to setup RBAC rules based on membership in groups. Guard supports following auth providers:
+
+Guard by AppsCode is a [Kubernetes Webhook Authentication](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication) server. Using guard, you can log into your Kubernetes cluster using various auth providers. Guard also configures groups of authenticated user appropriately. This allows cluster administrator to setup RBAC rules based on membership in groups. Guard supports following auth providers:
 
 - [Static Token File](https://appscode.com/products/guard/latest/guides/authenticator/static_token_file/)
 - [Github](https://appscode.com/products/guard/latest/guides/authenticator/github/)
@@ -17,16 +18,20 @@ Guard by AppsCode is a [Kubernetes Webhook Authentication](https://kubernetes.io
 - [Azure Active Directory via LDAP](https://appscode.com/products/guard/latest/guides/authenticator/ldap_azure/)
 
 ## Supported Versions
+
 Kubernetes 1.9+
 
 ## Installation
-To install Guard, please follow the guide [here](https://appscode.com/products/guard/latest/setup/install/).
+
+To install Guard, please follow the [Installation Guide](/docs/setup/install.md).
 
 ## Using Guard
-Want to learn how to use Guard? Please start [here](https://appscode.com/products/guard/latest/).
+
+Want to learn how to use Guard? Please see the [Guard Documentation](docs/README.md).
 
 ## Contribution guidelines
-Want to help improve Guard? Please start [here](https://appscode.com/products/guard/latest/welcome/contributing/).
+
+Want to help improve Guard? Please see the [Contributing Guide](/docs/CONTRIBUTING.md).
 
 ## Acknowledgement
 
@@ -34,6 +39,7 @@ Want to help improve Guard? Please start [here](https://appscode.com/products/gu
 - [Nike-Inc/harbormaster](https://github.com/Nike-Inc/harbormaster)
 
 ## Support
+
 We use Slack for public discussions. To chit chat with us or the rest of the community, join us in the [AppsCode Slack team](https://appscode.slack.com/messages/C8M8HANQ0/details/) channel `#guard`. To sign up, use our [Slack inviter](https://slack.appscode.com/).
 
 If you have found a bug with Guard or want to request for new features, please [file an issue](https://github.com/kubeguard/guard/issues/new).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ aliases:
 # Change Log
 
 ## [v0.6.2](https://go.kubeguard.dev/guard/tree/v0.6.2) (2020-09-24)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/v0.6.1...v0.6.2)
 
 **Closed issues:**
@@ -47,6 +48,7 @@ aliases:
 - Update to Kubernetes v1.18.3 [\#260](https://go.kubeguard.dev/guard/pull/260) ([1gtm](https://github.com/1gtm))
 
 ## [v0.6.1](https://go.kubeguard.dev/guard/tree/v0.6.1) (2020-06-05)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/v0.6.0...v0.6.1)
 
 **Merged pull requests:**
@@ -54,11 +56,12 @@ aliases:
 - Changed azure authz support to use v1beta1 version instead of v1 for SubjectAccessReview [\#259](https://go.kubeguard.dev/guard/pull/259) ([Anumita](https://github.com/Anumita))
 
 ## [v0.6.0](https://go.kubeguard.dev/guard/tree/v0.6.0) (2020-06-03)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/v0.6.0-rc.0...v0.6.0)
 
 **Closed issues:**
 
-- Missing files for os x  [\#249](https://go.kubeguard.dev/guard/issues/249)
+- Missing files for os x [\#249](https://go.kubeguard.dev/guard/issues/249)
 
 **Merged pull requests:**
 
@@ -67,6 +70,7 @@ aliases:
 - Update CHANGELOG.md [\#256](https://go.kubeguard.dev/guard/pull/256) ([tamalsaha](https://github.com/tamalsaha))
 
 ## [v0.6.0-rc.0](https://go.kubeguard.dev/guard/tree/v0.6.0-rc.0) (2020-06-02)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/v0.5.0...v0.6.0-rc.0)
 
 **Merged pull requests:**
@@ -76,6 +80,7 @@ aliases:
 - Update to Kubernetes 1.18.3 [\#253](https://go.kubeguard.dev/guard/pull/253) ([tamalsaha](https://github.com/tamalsaha))
 
 ## [v0.5.0](https://go.kubeguard.dev/guard/tree/v0.5.0) (2020-05-11)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/v0.5.0-rc.1...v0.5.0)
 
 **Merged pull requests:**
@@ -84,6 +89,7 @@ aliases:
 - Azure: switch to new graph endpoint for US Government cloud [\#250](https://go.kubeguard.dev/guard/pull/250) ([karataliu](https://github.com/karataliu))
 
 ## [v0.5.0-rc.1](https://go.kubeguard.dev/guard/tree/v0.5.0-rc.1) (2020-02-16)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/v0.5.0-rc.0...v0.5.0-rc.1)
 
 **Closed issues:**
@@ -101,6 +107,7 @@ aliases:
 - Add flag to call Graph api only when overage indicator is present [\#245](https://go.kubeguard.dev/guard/pull/245) ([weinong](https://github.com/weinong))
 
 ## [v0.5.0-rc.0](https://go.kubeguard.dev/guard/tree/v0.5.0-rc.0) (2020-01-26)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.4.0...v0.5.0-rc.0)
 
 **Closed issues:**
@@ -128,11 +135,12 @@ aliases:
 - typo in error command the it should be -o [\#214](https://go.kubeguard.dev/guard/pull/214) ([kanolato](https://github.com/kanolato))
 
 ## [0.4.0](https://go.kubeguard.dev/guard/tree/0.4.0) (2019-02-04)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.3.0...0.4.0)
 
 **Closed issues:**
 
-- Support Azure Active Directory in sovereign cloud  [\#208](https://go.kubeguard.dev/guard/issues/208)
+- Support Azure Active Directory in sovereign cloud [\#208](https://go.kubeguard.dev/guard/issues/208)
 - Dependabot couldn't find a Gopkg.toml for this project [\#205](https://go.kubeguard.dev/guard/issues/205)
 
 **Merged pull requests:**
@@ -144,6 +152,7 @@ aliases:
 - Support aad sovereign clouds [\#209](https://go.kubeguard.dev/guard/pull/209) ([karataliu](https://github.com/karataliu))
 
 ## [0.3.0](https://go.kubeguard.dev/guard/tree/0.3.0) (2018-12-03)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.2.1...0.3.0)
 
 **Fixed bugs:**
@@ -152,7 +161,7 @@ aliases:
 
 **Closed issues:**
 
-- Github connector docs asks for unnecessary public\_repo permissions [\#195](https://go.kubeguard.dev/guard/issues/195)
+- Github connector docs asks for unnecessary public_repo permissions [\#195](https://go.kubeguard.dev/guard/issues/195)
 - Guard should not log password/secrets [\#194](https://go.kubeguard.dev/guard/issues/194)
 - Issues with LDAP and guard get installer [\#193](https://go.kubeguard.dev/guard/issues/193)
 - Dependabot couldn't find a Gopkg.toml for this project [\#191](https://go.kubeguard.dev/guard/issues/191)
@@ -160,7 +169,7 @@ aliases:
 - Missing binaries for 0.2.1 guard-darwin [\#189](https://go.kubeguard.dev/guard/issues/189)
 - Guard pod keeps restarting ~ every 8 hours [\#187](https://go.kubeguard.dev/guard/issues/187)
 - Logo Proposal for Guard [\#184](https://go.kubeguard.dev/guard/issues/184)
-- Using Gitlab's full\_path instead of name while using authentication by Groups [\#181](https://go.kubeguard.dev/guard/issues/181)
+- Using Gitlab's full_path instead of name while using authentication by Groups [\#181](https://go.kubeguard.dev/guard/issues/181)
 - panic: assignment to entry in nil map [\#178](https://go.kubeguard.dev/guard/issues/178)
 
 **Merged pull requests:**
@@ -168,7 +177,7 @@ aliases:
 - Use docker build --pull [\#204](https://go.kubeguard.dev/guard/pull/204) ([tamalsaha](https://github.com/tamalsaha))
 - Prepare docs for 0.3.0 release [\#203](https://go.kubeguard.dev/guard/pull/203) ([tamalsaha](https://github.com/tamalsaha))
 - Fix Gitlab tests [\#202](https://go.kubeguard.dev/guard/pull/202) ([tamalsaha](https://github.com/tamalsaha))
-- Support group id or full\_path for Gitlab connector [\#201](https://go.kubeguard.dev/guard/pull/201) ([tamalsaha](https://github.com/tamalsaha))
+- Support group id or full_path for Gitlab connector [\#201](https://go.kubeguard.dev/guard/pull/201) ([tamalsaha](https://github.com/tamalsaha))
 - Document Github connector permissions to read:org [\#200](https://go.kubeguard.dev/guard/pull/200) ([tamalsaha](https://github.com/tamalsaha))
 - Redact password/secrets when dumping flags. [\#199](https://go.kubeguard.dev/guard/pull/199) ([tamalsaha](https://github.com/tamalsaha))
 - Revendor and run gofmt [\#198](https://go.kubeguard.dev/guard/pull/198) ([tamalsaha](https://github.com/tamalsaha))
@@ -182,6 +191,7 @@ aliases:
 - Log userinfo at klog.V\(10\) [\#180](https://go.kubeguard.dev/guard/pull/180) ([tamalsaha](https://github.com/tamalsaha))
 
 ## [0.2.1](https://go.kubeguard.dev/guard/tree/0.2.1) (2018-07-10)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.2.0...0.2.1)
 
 **Closed issues:**
@@ -199,11 +209,12 @@ aliases:
 - Add missing image in azure [\#169](https://go.kubeguard.dev/guard/pull/169) ([nightfury1204](https://github.com/nightfury1204))
 
 ## [0.2.0](https://go.kubeguard.dev/guard/tree/0.2.0) (2018-06-22)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.4...0.2.0)
 
 **Closed issues:**
 
-- Use a GUARD\_PKI\_DIR env variable [\#158](https://go.kubeguard.dev/guard/issues/158)
+- Use a GUARD_PKI_DIR env variable [\#158](https://go.kubeguard.dev/guard/issues/158)
 - Azure AAD auth provider is using AAD group's displayName instead of unique objectId for auth [\#153](https://go.kubeguard.dev/guard/issues/153)
 
 **Merged pull requests:**
@@ -212,7 +223,7 @@ aliases:
 - Fix flaky LDAP tests [\#167](https://go.kubeguard.dev/guard/pull/167) ([tamalsaha](https://github.com/tamalsaha))
 - Fix bad pointer in frame ldap.handleBind [\#166](https://go.kubeguard.dev/guard/pull/166) ([tamalsaha](https://github.com/tamalsaha))
 - Document --azure.use-group-uid flag [\#165](https://go.kubeguard.dev/guard/pull/165) ([tamalsaha](https://github.com/tamalsaha))
-- Add GUARD\_DATA\_DIR env variable [\#164](https://go.kubeguard.dev/guard/pull/164) ([tamalsaha](https://github.com/tamalsaha))
+- Add GUARD_DATA_DIR env variable [\#164](https://go.kubeguard.dev/guard/pull/164) ([tamalsaha](https://github.com/tamalsaha))
 - Various fixed based on goreportcard [\#163](https://go.kubeguard.dev/guard/pull/163) ([tamalsaha](https://github.com/tamalsaha))
 - Fix test command in make.py [\#162](https://go.kubeguard.dev/guard/pull/162) ([tamalsaha](https://github.com/tamalsaha))
 - Skip e2e tests from travis. [\#161](https://go.kubeguard.dev/guard/pull/161) ([tamalsaha](https://github.com/tamalsaha))
@@ -222,6 +233,7 @@ aliases:
 - User auth info added for AWS EKS [\#150](https://go.kubeguard.dev/guard/pull/150) ([sanjid133](https://github.com/sanjid133))
 
 ## [0.1.4](https://go.kubeguard.dev/guard/tree/0.1.4) (2018-06-20)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.3...0.1.4)
 
 **Closed issues:**
@@ -236,6 +248,7 @@ aliases:
 - Allow Azure AAD auth provider to use AAD group ids instead of display name for authn/authz [\#154](https://go.kubeguard.dev/guard/pull/154) ([amanohar](https://github.com/amanohar))
 
 ## [0.1.3](https://go.kubeguard.dev/guard/tree/0.1.3) (2018-06-06)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.2...0.1.3)
 
 **Merged pull requests:**
@@ -247,6 +260,7 @@ aliases:
 - Fix a typo in kubectl invocation [\#137](https://go.kubeguard.dev/guard/pull/137) ([farcaller](https://github.com/farcaller))
 
 ## [0.1.2](https://go.kubeguard.dev/guard/tree/0.1.2) (2018-05-04)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.1...0.1.2)
 
 **Merged pull requests:**
@@ -256,6 +270,7 @@ aliases:
 - Add paging to get around directoryObjects.getByIds limit of 1000 [\#133](https://go.kubeguard.dev/guard/pull/133) ([amanohar](https://github.com/amanohar))
 
 ## [0.1.1](https://go.kubeguard.dev/guard/tree/0.1.1) (2018-04-20)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.0...0.1.1)
 
 **Fixed bugs:**
@@ -287,6 +302,7 @@ aliases:
 - Update GitLab documentation to clarify the usage of base-url [\#111](https://go.kubeguard.dev/guard/pull/111) ([alexanderdavidsen](https://github.com/alexanderdavidsen))
 
 ## [0.1.0](https://go.kubeguard.dev/guard/tree/0.1.0) (2018-04-04)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.0-rc.5...0.1.0)
 
 **Closed issues:**
@@ -333,7 +349,7 @@ aliases:
 - Add travis.yml [\#78](https://go.kubeguard.dev/guard/pull/78) ([tamalsaha](https://github.com/tamalsaha))
 - Add test for google [\#77](https://go.kubeguard.dev/guard/pull/77) ([nightfury1204](https://github.com/nightfury1204))
 - Validate google IDToken [\#74](https://go.kubeguard.dev/guard/pull/74) ([nightfury1204](https://github.com/nightfury1204))
-- Print id\_token & refresh\_token for Google [\#73](https://go.kubeguard.dev/guard/pull/73) ([tamalsaha](https://github.com/tamalsaha))
+- Print id_token & refresh_token for Google [\#73](https://go.kubeguard.dev/guard/pull/73) ([tamalsaha](https://github.com/tamalsaha))
 - Add test for LDAP [\#70](https://go.kubeguard.dev/guard/pull/70) ([nightfury1204](https://github.com/nightfury1204))
 - Bug fixes and add CA cert flag for LDAP [\#69](https://go.kubeguard.dev/guard/pull/69) ([nightfury1204](https://github.com/nightfury1204))
 - Add test for azure [\#68](https://go.kubeguard.dev/guard/pull/68) ([nightfury1204](https://github.com/nightfury1204))
@@ -353,6 +369,7 @@ aliases:
 - Document how to use kube-dns to connect api server to guard server [\#47](https://go.kubeguard.dev/guard/pull/47) ([tamalsaha](https://github.com/tamalsaha))
 
 ## [0.1.0-rc.5](https://go.kubeguard.dev/guard/tree/0.1.0-rc.5) (2018-01-04)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.0-rc.4...0.1.0-rc.5)
 
 **Closed issues:**
@@ -382,6 +399,7 @@ aliases:
 - Use client-go 5.x [\#27](https://go.kubeguard.dev/guard/pull/27) ([tamalsaha](https://github.com/tamalsaha))
 
 ## [0.1.0-rc.4](https://go.kubeguard.dev/guard/tree/0.1.0-rc.4) (2017-09-25)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.0-rc.3...0.1.0-rc.4)
 
 **Merged pull requests:**
@@ -392,9 +410,11 @@ aliases:
 - Fix docs of Developer-guide [\#23](https://go.kubeguard.dev/guard/pull/23) ([the-redback](https://github.com/the-redback))
 
 ## [0.1.0-rc.3](https://go.kubeguard.dev/guard/tree/0.1.0-rc.3) (2017-09-07)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.0-rc.2...0.1.0-rc.3)
 
 ## [0.1.0-rc.2](https://go.kubeguard.dev/guard/tree/0.1.0-rc.2) (2017-09-01)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.0-rc.1...0.1.0-rc.2)
 
 **Merged pull requests:**
@@ -402,6 +422,7 @@ aliases:
 - Make sure user of member of Github org or GSuite domain [\#22](https://go.kubeguard.dev/guard/pull/22) ([tamalsaha](https://github.com/tamalsaha))
 
 ## [0.1.0-rc.1](https://go.kubeguard.dev/guard/tree/0.1.0-rc.1) (2017-08-30)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.0-rc.0...0.1.0-rc.1)
 
 **Merged pull requests:**
@@ -409,15 +430,17 @@ aliases:
 - Improve logging for Guard server [\#20](https://go.kubeguard.dev/guard/pull/20) ([tamalsaha](https://github.com/tamalsaha))
 
 ## [0.1.0-rc.0](https://go.kubeguard.dev/guard/tree/0.1.0-rc.0) (2017-08-29)
+
 [Full Changelog](https://go.kubeguard.dev/guard/compare/0.1.0-alpha.0...0.1.0-rc.0)
 
 **Merged pull requests:**
 
 - Document ClusterIP choice [\#16](https://go.kubeguard.dev/guard/pull/16) ([tamalsaha](https://github.com/tamalsaha))
-- Various fixes  [\#15](https://go.kubeguard.dev/guard/pull/15) ([tamalsaha](https://github.com/tamalsaha))
+- Various fixes [\#15](https://go.kubeguard.dev/guard/pull/15) ([tamalsaha](https://github.com/tamalsaha))
 - Refactor handlers [\#12](https://go.kubeguard.dev/guard/pull/12) ([tamalsaha](https://github.com/tamalsaha))
 
 ## [0.1.0-alpha.0](https://go.kubeguard.dev/guard/tree/0.1.0-alpha.0) (2017-08-28)
+
 **Closed issues:**
 
 - Gtihub Teams [\#2](https://go.kubeguard.dev/guard/issues/2)
@@ -433,6 +456,4 @@ aliases:
 - Implement authN webhook for Google and Github [\#4](https://go.kubeguard.dev/guard/pull/4) ([tamalsaha](https://github.com/tamalsaha))
 - Implement init commands [\#3](https://go.kubeguard.dev/guard/pull/3) ([tamalsaha](https://github.com/tamalsaha))
 
-
-
-\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*
+\* _This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)_

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,6 +16,7 @@ aliases:
 ---
 
 # Contribution Guidelines
+
 Want to hack on Guard?
 
 AppsCode projects are [Apache 2.0 licensed](https://go.kubeguard.dev/guard/blob/master/LICENSE) and accept contributions via
@@ -46,7 +47,7 @@ If you have found a bug with Guard or want to request for new features, please [
 
 ## Submit PR
 
-If you fix a bug or developed a new feature, feel free to submit a PR. In either case, please file a [Github issue](https://go.kubeguard.dev/guard/issues/new) first, so that we can have a discussion on it. This is a rough outline of what a contributor's workflow looks like:
+If you fix a bug or developed a new feature, feel free to submit a PR. In either case, please file a [Github issue](https://github.com/kubeguard/guard/issues/new) first, so that we can have a discussion on it. This is a rough outline of what a contributor's workflow looks like:
 
 - Create a topic branch from where you want to base your work (usually master).
 - Make commits of logical units.

--- a/docs/examples/installer.yaml
+++ b/docs/examples/installer.yaml
@@ -75,4 +75,3 @@ spec:
   type: ClusterIP
 status:
   loadBalancer: {}
-

--- a/docs/guides/authenticator/aws_eks.md
+++ b/docs/guides/authenticator/aws_eks.md
@@ -14,7 +14,7 @@ section_menu_id: guides
 
 # Amazon EKS
 
-Guard installation guide can be found [here](/docs/setup/install.md). Install the Guard on your system by following `Install Guard as CLI`.
+The [Guard installation guide](/docs/setup/install.md) contains setup instructions. Install the Guard on your system by following `Install Guard as CLI`.
 
 ### Configure Kubectl
 
@@ -57,18 +57,22 @@ users:
         -  "eks"
 ```
 
-Here,
-1. Replace the `<endpoint-url>` with endpoint URL, which can be retrieved by following command
-```console
-$ aws eks describe-cluster --name <cluster-name>  --query cluster.endpoint
-```
+Here:
 
-2. Replace the `<base64-encoded-ca-cert>` with the certificate authority data, which can be retrieved by following command
-```console
-$ aws eks describe-cluster --name <cluster-name>  --query cluster.certificateAuthority.data
-```
+1. Replace the `<endpoint-url>` with endpoint URL, which can be retrieved by following command:
 
-To test the configuration run
-```console
-$ kubectl get pods --all-namespaces
-```
+  ```console
+  $ aws eks describe-cluster --name <cluster-name>  --query cluster.endpoint
+  ```
+
+1. Replace the `<base64-encoded-ca-cert>` with the certificate authority data, which can be retrieved by following command:
+
+  ```console
+  $ aws eks describe-cluster --name <cluster-name>  --query cluster.certificateAuthority.data
+  ```
+
+To test the configuration run:
+
+  ```console
+  $ kubectl get pods --all-namespaces
+  ```

--- a/docs/guides/authenticator/azure.md
+++ b/docs/guides/authenticator/azure.md
@@ -14,7 +14,7 @@ section_menu_id: guides
 
 # Azure Authenticator
 
-Guard installation guide can be found [here](/docs/setup/install.md). To use Azure, create a client cert with `Organization` set to `Azure`.For Azure `CommonName` is optional. To ease this process, use the Guard cli to issue a client cert/key pair.
+The [Guard installation guide](/docs/setup/install.md) contains setup instructions. To use Azure, create a client cert with `Organization` set to `Azure`.For Azure `CommonName` is optional. To ease this process, use the Guard cli to issue a client cert/key pair.
 
 ```console
 $ guard init client [CommonName] -o Azure
@@ -40,6 +40,7 @@ $ guard get installer \
 
 $ kubectl apply -f installer.yaml
 ```
+
 > **Note:** guard take `<application_secret>` from environment variable **AZURE_CLIENT_SECRET**.
 
 Procedure to find `<application_id>`, `<application_secret>` are given below. Replace the `<tenant_id>` with your azure tenant id.
@@ -85,23 +86,23 @@ $ kubectl apply -f installer.yaml
 
 Configuring Azure AD as a auth provider requires an initial setup by `Global Administrator` of such AD. This involves a complex multi-step process. Please see the video above to setup your Azure AD.
 
-1.  Sign in to the [Azure portal](https://portal.azure.com/). Please make sure that you are a `Global Administrator` of your Azure AD. If not, please contact your Azure AD administrator to perform these steps.
+1. Sign in to the [Azure portal](https://portal.azure.com/). Please make sure that you are a `Global Administrator` of your Azure AD. If not, please contact your Azure AD administrator to perform these steps.
 
     ![aad-dir-role](/docs/images/azure/dir-role.png)
 
-2.  Create an Azure Active Directory Web App / API application
+2. Create an Azure Active Directory Web App / API application
 
     ![create-app-registration](/docs/images/azure/create-app-registration.png)
 
-3.  Use the **Application ID** as `<application_id>`
+3. Use the **Application ID** as `<application_id>`
 
     ![application-id](/docs/images/azure/application-id.png)
 
-4.  Click on the **Settings**, click on the **key** , generate a key and use this key as `<application_secret>`
+4. Click on the **Settings**, click on the **key** , generate a key and use this key as `<application_secret>`
 
     ![secret-key](/docs/images/azure/secret-key.png)
 
-5.  Add **Microsoft Graph** api with _application permission_ `Read directory data` and _delegated permission_ `Read directory data` and `Sign in and read user profile`.
+5. Add **Microsoft Graph** api with _application permission_ `Read directory data` and _delegated permission_ `Read directory data` and `Sign in and read user profile`.
 
     ![add-api](/docs/images/azure/add-api.png)
     ![add-api-2](/docs/images/azure/add-api-2.png)
@@ -111,15 +112,15 @@ Configuring Azure AD as a auth provider requires an initial setup by `Global Adm
     ![guard-grant-perm](/docs/images/azure/guard-grant-perm.png)
     ![guard-permissions](/docs/images/azure/guard-permissions.png)
 
-7.  Create a second Azure Active Directory native application
+7. Create a second Azure Active Directory native application
 
     ![create-native-app](/docs/images/azure/create-native-app.png)
 
-8.  Use the **Application ID** of this native app as `<client_id>`
+8. Use the **Application ID** of this native app as `<client_id>`
 
     ![client-id](/docs/images/azure/client-id.png)
 
-9.  Add application created at step 2 with permission `Access <Application_Name_Created_At_Step_2>`
+9. Add application created at step 2 with permission `Access <Application_Name_Created_At_Step_2>`
 
     ![add-guard-app](/docs/images/azure/add-guard-api.png)
 
@@ -143,6 +144,7 @@ $ guard get installer \
 
 $ kubectl apply -f installer.yaml
 ```
+
 > **Note:** Guard takes `<application_secret>` from environment variable **AZURE_CLIENT_SECRET**.
 
 ### Configure Azure Active Directory App
@@ -188,7 +190,7 @@ users:
 
 The access token is acquired when first `kubectl` command is executed
 
-   ```
+   ```console
    $ kubectl get pods --user <user_name>
 
    To sign in, use a web browser to open the page https://aka.ms/devicelogin and enter the code DEC7D48GA to authenticate.
@@ -214,9 +216,10 @@ However, if it is desired to disable such validation, update below option
     --azure.verify-clientID=false
 ```
 
-## Further Reading:
-- https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications
-- https://github.com/kubernetes/client-go/blob/master/plugin/pkg/client/auth/azure/README.md
-- https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow
-- https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#payload-claims
-- https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#validating-tokens
+## Further Reading
+
+- <https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications>
+- <https://github.com/kubernetes/client-go/blob/master/plugin/pkg/client/auth/azure/README.md>
+- <https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow>
+- <https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#payload-claims>
+- <https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#validating-tokens>

--- a/docs/guides/authenticator/github.md
+++ b/docs/guides/authenticator/github.md
@@ -14,7 +14,7 @@ section_menu_id: guides
 
 # Github Authenticator
 
-Guard installation guide can be found [here](/docs/setup/install.md). To use Github, you need a client cert with `CommonName` set to Github organization name and `Organization` set to `Github`. To ease this process, use the Guard cli to issue a client cert/key pair.
+The [Guard installation guide](/docs/setup/install.md) contains setup instructions. To use Github, you need a client cert with `CommonName` set to Github organization name and `Organization` set to `Github`. To ease this process, use the Guard cli to issue a client cert/key pair.
 
 ```console
 $ guard init client {common-name} -o Github
@@ -41,6 +41,7 @@ Additional flags for github:
 ```
 
 ### Issue Token
+
 To use Github authentication, you can use your personal access token with permission to `read:org`. You can use the following command to issue a token:
 
 ```console
@@ -72,6 +73,7 @@ Guard uses the token found in `TokenReview` request object to read user's profil
 ```
 
 ### Configure Kubectl
+
 ```console
 kubectl config set-credentials <user_name> --token=<token>
 ```
@@ -94,5 +96,4 @@ kube-system   kube-addon-manager-minikube        1/1       Running   0          
 kube-system   kube-apiserver-minikube            1/1       Running   1          7h
 kube-system   kube-controller-manager-minikube   1/1       Running   0          7h
 kube-system   kube-dns-6f4fd4bdf-f7csh           3/3       Running   0          7h
-
 ```

--- a/docs/guides/authenticator/gitlab.md
+++ b/docs/guides/authenticator/gitlab.md
@@ -14,7 +14,7 @@ section_menu_id: guides
 
 # Gitlab Authenticator
 
-Guard installation guide can be found [here](/docs/setup/install.md). To use Gitlab, you need a client cert with `Organization` set to `Gitlab`. To ease this process, use the Guard cli to issue a client cert/key pair.
+The [Guard installation guide](/docs/setup/install.md) can be found in our documentation. To use Gitlab, you need a client cert with `Organization` set to `Gitlab`. To ease this process, use the Guard cli to issue a client cert/key pair.
 
 ```console
 $ guard init client {common-name} -o Gitlab

--- a/docs/guides/authenticator/google.md
+++ b/docs/guides/authenticator/google.md
@@ -13,6 +13,7 @@ section_menu_id: guides
 ---
 
 # Google Authenticator
+
 To use Google, you need a client cert with `CommonName` set to Google Apps (now G Suite) domain and `Organization` set to `Google`. To ease this process, use the Guard cli to issue a client cert/key pair.
 
 ```console
@@ -20,9 +21,11 @@ $ guard init client {domain-name} -o Google
 ```
 
 ## G Suite Domain-Wide Delegation of Authority
-Guard server needs to determine the list of groups for any user in a G suite domain. This requires the domain administrator to grant Guard server with domain-wide access to its users' data — this is referred as domain-wide delegation of authority. The following procedure has been adapted from official documentation found [here](https://developers.google.com/admin-sdk/directory/v1/guides/delegation).
+
+Guard server needs to determine the list of groups for any user in a G suite domain. This requires the domain administrator to grant Guard server with domain-wide access to its users' data — this is referred as domain-wide delegation of authority. The following procedure has been adapted from the [official Google documentation](https://developers.google.com/admin-sdk/directory/v1/guides/delegation).
 
 ### Create the service account and its credentials
+
 G Suite domain administrator needs to create a service account and its credentials. During this procedure you need to gather information that will be later passed to Guard server installer.
 
 - Open the [Service accounts page](https://console.developers.google.com/permissions/serviceaccounts). If prompted, select a project.
@@ -32,6 +35,7 @@ G Suite domain administrator needs to create a service account and its credentia
 You should now have gathered your service account's Private Key file, Client ID and email address. You are ready to delegate domain-wide authority to your service account.
 
 ### Delegate domain-wide authority to your service account
+
 The service account that you created needs to be granted access to the G Suite domain’s user data that Guard server needs to access. The following tasks have to be performed by an administrator of the G Suite domain:
 
 - Go to your G Suite domain’s [Admin console page for managing API client access](https://admin.google.com/ManageOauthClients).
@@ -42,7 +46,8 @@ The service account that you created needs to be granted access to the G Suite d
 Your service account now has domain-wide access to the Google Admin SDK Directory API for all the users of your domain. Only users with access to the Admin APIs can access the Admin SDK Directory API, therefore your service account needs to impersonate one of those users to access the Admin SDK Directory API.
 
 ## Deploy Guard Server
-For detailed instructions follow the guide [here](/docs/setup/install.md). To generate correct installer YAMLs for Guard server, pass the flags `--google.admin-email` and `--google.sa-json-file`.
+
+For detailed instructions follow the [Installation Guide](/docs/setup/install.md). To generate correct installer YAMLs for Guard server, pass the flags `--google.admin-email` and `--google.sa-json-file`.
 
 ```console
 # generate Kubernetes YAMLs for deploying guard server
@@ -56,6 +61,7 @@ $ kubectl apply -f installer.yaml
 ```
 
 ![google-webhook-flow](/docs/images/google-webhook-flow.png)
+
 ```json
 {
   "apiVersion": "authentication.k8s.io/v1",
@@ -73,17 +79,20 @@ $ kubectl apply -f installer.yaml
   }
 }
 ```
+
 Guard uses the token found in `TokenReview` request object to read user's profile information and list of Google Groups this user is member of. In the `TokenReview` response, `status.user.username` is set to user's Google email, `status.user.groups` is set to email of Google groups under the domain found in client cert of which this user is a member of.
 
 ## Configure kubectl
 
 You can use the following command to issue a token:
-```
+
+```console
 $ guard get token -o google
 ```
 
 This will open a login window in your browser. After logged into your account, user info will be written in `~/.kube/config`. Your email will be used for user name.
-```
+
+```console
 $ guard get token -o google
 I0312 12:36:40.927613   14596 logs.go:19] FLAG: --alsologtostderr="false"
 I0312 12:36:40.927770   14596 logs.go:19] FLAG: --analytics="true"
@@ -119,4 +128,3 @@ $ kubectl get pods --user <your_email>
 NAMESPACE     NAME                                    READY     STATUS    RESTARTS   AGE
 kube-system   kube-dns-54cccfbdf8-jf9p2               3/3       Running   0          6h
 ```
-

--- a/docs/guides/authenticator/ldap.md
+++ b/docs/guides/authenticator/ldap.md
@@ -14,7 +14,7 @@ section_menu_id: guides
 
 # LDAP Authenticator
 
-Guard installation guide can be found [here](/docs/setup/install.md). To use LDAP, create a client cert with `Organization` set to `Ldap`. For LDAP `CommonName` is optional. To ease this process, use the Guard cli to issue a client cert/key pair.
+The [Guard installation guide](/docs/setup/install.md) contains setup instructions. To use LDAP, create a client cert with `Organization` set to `Ldap`. For LDAP `CommonName` is optional. To ease this process, use the Guard cli to issue a client cert/key pair.
 
 ```console
 # If CommonName is not provided, then default CommonName `ldap` is used
@@ -219,6 +219,7 @@ kube-system   kube-dns-6f4fd4bdf-f7csh           3/3       Running   0          
 ```
 
 **Flag** details for get token:
+
 ```console
 # LDAP user authentication mechanism
 #   - 0 for simple authentication

--- a/docs/guides/authenticator/ldap_azure.md
+++ b/docs/guides/authenticator/ldap_azure.md
@@ -14,17 +14,17 @@ section_menu_id: guides
 
 # Authenticate using secure LDAP of Azure Active Directory Domain Services
 
-There is a nice documentation about how to enable secure LDAP for the managed domain using Azure portal [here](https://docs.microsoft.com/en-us/azure/active-directory-domain-services/active-directory-ds-admin-guide-configure-secure-ldap-enable-ldaps). If you configured DNS to access the managed domain, then use it as `SERVER_ADDRESS`. If not configured, then you can use **EXTERNAL IP ADDRESS FOR LDAPS ACCESS** as `SERVER_ADDRESS`. For LDAPS use `636` as server `PORT`. Procedure to find **EXTERNAL IP ADDRESS FOR LDAPS ACCESS** is given below:
+There is a nice documentation about how to enable secure LDAP for the managed domain using Azure portal in the [Azure official documentation](https://docs.microsoft.com/en-us/azure/active-directory-domain-services/active-directory-ds-admin-guide-configure-secure-ldap-enable-ldaps). If you configured DNS to access the managed domain, then use it as `SERVER_ADDRESS`. If not configured, then you can use **EXTERNAL IP ADDRESS FOR LDAPS ACCESS** as `SERVER_ADDRESS`. For LDAPS use `636` as server `PORT`. Procedure to find **EXTERNAL IP ADDRESS FOR LDAPS ACCESS** is given below:
 
-1.  Write `domain services` in the Search resources search box. Select Azure AD Domain Services from the search result.
+1. Write `domain services` in the Search resources search box. Select Azure AD Domain Services from the search result.
 
 ![azure-azure-ADDS](/docs/images/ldap-azure/azure-ADDS.png)
 
-2.  Click the name of the managed domain(for example: appscode.com)
+1. Click the name of the managed domain(for example: appscode.com)
 
 ![azure-ADDS-home](/docs/images/ldap-azure/azure-ADDS-home.png)
 
-3.  Click the **Properties** and find the **SECURE LDAP EXTERNAL IP ADDRESS**
+1. Click the **Properties** and find the **SECURE LDAP EXTERNAL IP ADDRESS**
 
 ![azure-ADDS-properties](/docs/images/ldap-azure/azure-ADDS-properties.png)
 
@@ -32,7 +32,7 @@ There is a nice documentation about how to enable secure LDAP for the managed do
 
 ### Guard Installation and PKI Initialization
 
-Guide for Guard installation and PKI initialization are given [here](/docs/setup/install.md).
+Guide for [Guard installation and PKI initialization](/docs/setup/install.md) are given in our documentation.
 Create a client cert with `Organization` set to `Ldap`.For LDAP `COMMON_NAME` is optional. To ease this process, use the Guard cli to issue a client cert/key pair.
 
 ```console
@@ -43,6 +43,7 @@ Create a client cert with `Organization` set to `Ldap`.For LDAP `COMMON_NAME` is
 ### Deploy guard server
 
 Now deploy Guard server so that your Kubernetes api server can access it. Use the command below to generate YAMLs for your particular setup. Then use `kubectl apply -f` to install Guard server.
+
 ```console
      # generate Kubernetes YAMLs for deploying guard server
      $  guard get installer \
@@ -69,6 +70,7 @@ Now deploy Guard server so that your Kubernetes api server can access it. Use th
 > **Note:** Azure managed domain LDAPS doesn't support start TLS
 
 ### Configure Kubernetes API Server
+
 To use webhook authentication, you need to set `--authentication-token-webhook-config-file` flag of your Kubernetes api server to a [kubeconfig file](https://kubernetes.io/docs/admin/authentication/#webhook-token-authentication) describing how to access the Guard webhook service. You can use the following command to generate a sample `kubeconfig` file.
 
 ```console
@@ -95,12 +97,15 @@ users:
     client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMyakNDQWNLZ0F3SUJBZ0lJQTZJZmR0dEIzTlV3RFFZSktvWklodmNOQVFFTEJRQXdEVEVMTUFrR0ExVUUKQXhNQ1kyRXdIaGNOTVRjd09ESTVNVFF5TXpNNFdoY05NVGd3T0RJNU1UUXlOREEwV2pBa01ROHdEUVlEVlFRSwpFd1pIYVhSb2RXSXhFVEFQQmdOVkJBTVRDR0Z3Y0hOamIyUmxNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DCkFROEFNSUlCQ2dLQ0FRRUE3NG5nc25IcldkeHovZUNWdEVwVUdVcmQ1dWkwSVhteGFkZlVuM3hpVTduZHdsYzgKc2loT1hLQ2pEaWM5cjZweW16MTJ5Ry93WCtZM1diOUU5a0VxQzg5L2oyR0ZrSFNVOU40VFlsQlZka0pSRUQ2dAoySjZpVnNPZE9BeE9MeDNidG5QR3RYNi9KRTZSTVFCLzhkcUYyenFUZm5ST3FFNFE0N01wL0NKYmdkcEpjbm9mCmdKVzN5Z2pJYk96WHhIZVNNcjlIclhveGRLbGFPVk1hU3BmY0RVREZrQXV1MEREZCszT3hwbG03TlNpS2JpbnUKM0d3VDc4YkRtNzZCTCtEOWhKeXB2OVZDTFkyMVB3WnB3ejJmaThYdzN2WDM3VVdPenA0OXlCMyttYnVjWkpGSgpCRTNORVJyZFVvWFhyeUJrdDhEdXp0SzhYM3dhOExGdmsvOWxWd0lEQVFBQm95Y3dKVEFPQmdOVkhROEJBZjhFCkJBTUNCYUF3RXdZRFZSMGxCQXd3Q2dZSUt3WUJCUVVIQXdJd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFFN0YKZkdpOWpDSzc0eGZZdmY3b3Byb1NxSVpoYmdyODVkcENCZ2FVbEhlK0ZJYkpVeWhnL2c2OVNCOUlhWitpTWYxNgpNWkJVTWs4Tmg5dUZWYWVQVUdCWG0vTUtBeGx0V0J0UHh0VFFMV0cycU9LbXczK3Z5UUJ4R2JMaytycndXVS9YCjR5SzcxbWc5ZG5GVXdWOGI2UWtwM1IxMVdCZzlCeHExU1RQL210S2NyNVVDS3ZWVmlEYlpobzRkRy9ZUHdMbEUKS1N4UGtqS3NPVU54dDlHZkdNTHVRMVFQWXZDYTZjZ1MxN3BERWZacWVqdmthc0UxeTNSQWpPa2pubTJ2KzIzbgpBN2kxYWwwMDZjTEpQdTl3S3IyMzhJQ0Q3N2ZxQzhTaXJhN3V3NUgxbkVvMTh1am94NmI2UG5XazdmeTZabDRHCjBWMXBCSDJtL1JqK0RudGVTM0k9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
     client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBNzRuZ3NuSHJXZHh6L2VDVnRFcFVHVXJkNXVpMElYbXhhZGZVbjN4aVU3bmR3bGM4CnNpaE9YS0NqRGljOXI2cHltejEyeUcvd1grWTNXYjlFOWtFcUM4OS9qMkdGa0hTVTlONFRZbEJWZGtKUkVENnQKMko2aVZzT2RPQXhPTHgzYnRuUEd0WDYvSkU2Uk1RQi84ZHFGMnpxVGZuUk9xRTRRNDdNcC9DSmJnZHBKY25vZgpnSlczeWdqSWJPelh4SGVTTXI5SHJYb3hkS2xhT1ZNYVNwZmNEVURGa0F1dTBERGQrM094cGxtN05TaUtiaW51CjNHd1Q3OGJEbTc2QkwrRDloSnlwdjlWQ0xZMjFQd1pwd3oyZmk4WHczdlgzN1VXT3pwNDl5QjMrbWJ1Y1pKRkoKQkUzTkVScmRVb1hYcnlCa3Q4RHV6dEs4WDN3YThMRnZrLzlsVndJREFRQUJBb0lCQVFDam9LdTlPZFJyTGd5TwpBRHhEVEFMbXhCMlEvcVVOdVBOWU9mY2tldk12L21kZHVmbmNPV3hPR2UxSVhjWGxtYWx3SWl4aC94VlViUTZpClgrWGIwZWZHNlpkWmVtU2lxUUNYeEp1NUxPYzBRVmplbi9KaFp2dStDU0g4aDJ0aEJDUnlIZVEvVnJWN043QTIKcVFDOVZXamF1TWpJT09zQ1RWRjhPWWNVbE9PdGJ2MFFRSUFNRDdxak1jcTdIRlJMbjlHSXJjSGVZWTd2RTdONQpucFdOMWZOT25BZXNnaVNRcGYxdGNYcmJUckNkb1JweExlU2RFUngyVnBkdFE1V3hFTm9YYURJT3FJVXB2anJaCjIwSUZqazY3eVVOTlBCLzJkU3VmZzVaekxEYWNGUy9lenYvUDVJYnVEazBHZWQyZGhkT2t3K2duVFNabjg0Sk4KMDg4TlMvVUJBb0dCQVBGOG44dEVmTURDNjlTc1RGWWh4NUc2aE1PWThlS0kxTDJQeTVVaEN4WCtXUlpoQndaVQpWaGhVMVpOcTgvUXkwb201WEQyT1UwR0tGQjY3aE9kU1l6TUc3a0NqKzl3bHZDM0loRmxLd2R1ZC8relBWTFkvCngxRjFtVnA3aTllZXZiZmdZdUQxdDRvTDVxc2lveldGZ2g2UndSZzVWTXpGd0N2WXZwUk9CcGZUQW9HQkFQM3YKUjNyRit1cW96YU9IcldrUjFEL3E5MHlRd3ZpamlRWDhyNEg3QVZTVVpnQmhwbEpmUDRTVU84NWdUbmhBLzl4ZQp3R1NTQzFGWkpVeDRmOW41MFN0dFlkNFhIMTZiU1lyOEpWQWxVRWY5QWR1czBkc1pKdkZLSEM5S3VjNEFPeUFPClYvUGR0Rk1FV2J5WERSQXdBTTVwNzZsU1pZVXA5cDFLVTZ6SndHM3RBb0dCQUlmdzdRK0RmV3NTRDZwSVdDekEKbFZUL0Y4LzRZR3B6TnJlRHBFcE9NS3h2NDN6S29DYTdBVUJ2T1Uva2pISnl6YnlFSVYzeHFnS2lGVk43b29TSwpCNWZwRmVSRHEvdXhMbTdqaTBXczVOYVo2a0ZJTWRycXFteTc4OWxRNVZjN1lIZUxsSDRwTk9vOGF0ejZBY0NXCmFMcUd1Sm5IWkdwbUJCbHF5Vlk1V2xMTEFvR0FPWVlBelVFWURCeGRLUlJOSmlZUnpNRHZjSHJDa0F5THQ3MTgKREpmTnYxazJtaE9FMTlnWHpYSys4WXREZTE1T0Y1K25PYUVUeTBQRWZVUTJ3aXdqUkJFdFFHQkFqTy9rZ3dXSApkbFpkajFFeklJNVBvN0JZOEFQM3lvYkUvSE4wOFZnT2VJSGFuWXU0d0UzL2VaRkdQWHdsL0ZkY0JBUnpoMElWCkhtazluQ2tDZ1lFQXJyNGQ3WFBUNlBvTTA5TjFSYnVtQnROUW96cGxpb0wwb0tqZUxHL0RHcUd5Q3lpcDVsNnMKUW5vblpPcW9BVzdqZlRiMThvVVVzVkJTdDJvd20zempac05XZFdZcEptL1ZCSDQvY0dOeFJuSXN1OFNsdFdBZAp1YjVZQS9YcnEvUTRNcUJnZEVwYm9HTnlzUVlscE0rMmxHZWpiZ0pDUTI4b3dJYndLQ3JSY2t3PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
 ```
+
 ### Configure Kubectl
+
 ```console
 kubectl config set-credentials [USERNAME] --token=[TOKEN]
 ```
 
 Or You can add user in ~/.kube/config file
+
 ```yaml
 ...
 users:
@@ -117,4 +122,3 @@ So, use base64 encoded string of `[USERNAME]:[PASSWORD]` as token.
 |username |password |username:password     |token
 |---------|---------|----------------------|------------------
 |user12   |12345    |user12:12345          |dXNlcjEyOjEyMzQ1
-

--- a/docs/guides/authenticator/static_token_file.md
+++ b/docs/guides/authenticator/static_token_file.md
@@ -26,6 +26,7 @@ $ guard get installer \
 
 $ kubectl apply -f installer.yaml
 ```
+
 ![github-webhook-flow](/docs/images/token-auth-webhook-flow.png)
 
 ```json
@@ -37,10 +38,7 @@ $ kubectl apply -f installer.yaml
     "user": {
       "username": "<user-name>",
       "uid": "<user-id>",
-      "groups": [
-        "<group-1>",
-        "<group-2>"
-      ]
+      "groups": ["<group-1>", "<group-2>"]
     }
   }
 }
@@ -49,15 +47,17 @@ $ kubectl apply -f installer.yaml
 Guard uses the token found in `TokenReview` request object to get user's information and list of groups this user is member of. In the `TokenReview` response, `status.user.username`, `status.user.uid` and `status.user.groups` are set to username, userid and groups found in token file.
 
 ### Token file
+
 Token file is a csv file containing four columns: token, username, user uid and group names. Group names column may be empty or contain multiple names. Token must be unique for each user.
 
-|username |uid      |token                 |List groups user is member of
-|---------|---------|----------------------|----------------------------------
-|user1    |1123     |alkskjhfdku3jkfhm     |test,dev
-|user2    |566      |kjasdfgjkewyucxmj12   |dev
-|user3    |7654     |lskdfjldskfnkjhf      |
+| username | uid  | token               | List groups user is member of |
+| -------- | ---- | ------------------- | ----------------------------- |
+| user1    | 1123 | alkskjhfdku3jkfhm   | test,dev                      |
+| user2    | 566  | kjasdfgjkewyucxmj12 | dev                           |
+| user3    | 7654 | lskdfjldskfnkjhf    |                               |
 
 For above user's, token file is given below:
+
 ```console
 $ cat token.csv
 alkskjhfdku3jkfhm,user1,1123,"test,dev"
@@ -65,7 +65,9 @@ kjasdfgjkewyucxmj12,user2,566,dev
 lskdfjldskfnkjhf,user3,7654,
 
 ```
+
 ### Configure Kubectl
+
 ```console
 kubectl config set-credentials <user_name> --token=<token>
 ```
@@ -73,12 +75,14 @@ kubectl config set-credentials <user_name> --token=<token>
 Or You can add user in .kube/config file
 
 ```yaml
+
 ...
 users:
-- name: <user_name>
-  user:
-    token: <token>
+  - name: <user_name>
+    user:
+      token: <token>
 ```
+
 ```console
 $ kubectl get pods --all-namespaces --user <user_name>
 NAMESPACE     NAME                               READY     STATUS    RESTARTS   AGE

--- a/docs/guides/authorizer/azure.md
+++ b/docs/guides/authorizer/azure.md
@@ -14,14 +14,13 @@ section_menu_id: guides
 
 # Azure Authorizer
 
-Guard installation guide can be found [here](/docs/setup/install.md). To use Azure, create a client cert with `Organization` set to `Azure`.For Azure `CommonName` is optional. To ease this process, use the Guard cli to issue a client cert/key pair.
+The [Guard installation guide](/docs/setup/install.md) contains setup instructions. To use Azure, create a client cert with `Organization` set to `Azure`.For Azure `CommonName` is optional. To ease this process, use the Guard cli to issue a client cert/key pair.
 
 ```console
 $ guard init client [CommonName] -o Azure
 ```
 
-Azure authenticator guide can be found [here](/docs/guides/authenticator/azure.md).
-
+See the [Azure authentication guide](/docs/guides/authenticator/azure.md) for more information.
 
 ## ARC mode
 
@@ -53,6 +52,7 @@ $ kubectl apply -f installer.yaml
 > Keep azure.skip-authz-for-non-aad-users=true for certificate users (non AAD users) to work with Azure authorization. You are required to set separate Kubernetes RBAC authorizer for certificate users.
 
 ## Further Reading:
-- https://docs.microsoft.com/en-us/azure/role-based-access-control/overview
-- https://docs.microsoft.com/en-us/azure/role-based-access-control/best-practices
-- https://aka.ms/AzureArcK8sDocs
+
+- <https://docs.microsoft.com/en-us/azure/role-based-access-control/overview>
+- <https://docs.microsoft.com/en-us/azure/role-based-access-control/best-practices>
+- <https://aka.ms/AzureArcK8sDocs>

--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -18,7 +18,7 @@ section_menu_id: guides
 
 Create a ServiceMonitor for [Prometheus-Operator](https://github.com/coreos/prometheus-operator) to automatically scrape Guard's metrics endpoint.
 
-```
+```yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -42,7 +42,7 @@ spec:
 
 If prometheus-operator and kube-prometheus is installed using CoreOS's [helm charts](https://github.com/coreos/prometheus-operator/tree/master/helm), the serviceMonitor can be defined in kube-prometheus's values.yaml.
 
-```
+```yaml
 prometheus:
   serviceMonitors:
     - name: guard
@@ -62,6 +62,6 @@ prometheus:
         any: true
 ```
 
-# Grafana Dashboard for Guard
+## Grafana Dashboard for Guard
 
-A simple Grafana dashbord for Guard can be found [here](https://go.kubeguard.dev/guard/raw/master/contrib/Guard-grafana-dashboard.json)
+A simple Grafana dashboard for Guard can be found in the [Guard Grafana dashboard JSON file](https://go.kubeguard.dev/guard/raw/master/contrib/Guard-grafana-dashboard.json)

--- a/docs/reference/guard.md
+++ b/docs/reference/guard.md
@@ -20,15 +20,14 @@ Guard by AppsCode - Kubernetes Authentication WebHook Server
 
 ### Options
 
-```
+```text
   -h, --help   help for guard
 ```
 
 ### SEE ALSO
 
-* [guard get](/docs/reference/guard_get.md)	 - Get PKI
-* [guard init](/docs/reference/guard_init.md)	 - Init PKI
-* [guard login](/docs/reference/guard_login.md)	 - Kubectl credential plugin
-* [guard run](/docs/reference/guard_run.md)	 - Run server
-* [guard version](/docs/reference/guard_version.md)	 - Prints binary version number.
-
+- [guard get](/docs/reference/guard_get.md) - Get PKI
+- [guard init](/docs/reference/guard_init.md) - Init PKI
+- [guard login](/docs/reference/guard_login.md) - Kubectl credential plugin
+- [guard run](/docs/reference/guard_run.md) - Run server
+- [guard version](/docs/reference/guard_version.md) - Prints binary version number.

--- a/docs/reference/guard_get.md
+++ b/docs/reference/guard_get.md
@@ -15,14 +15,13 @@ Get PKI
 
 ### Options
 
-```
+```text
   -h, --help   help for get
 ```
 
 ### SEE ALSO
 
-* [guard](/docs/reference/guard.md)	 - Guard by AppsCode - Kubernetes Authentication WebHook Server
-* [guard get installer](/docs/reference/guard_get_installer.md)	 - Prints Kubernetes objects for deploying guard server
-* [guard get token](/docs/reference/guard_get_token.md)	 - Get tokens for Azure/Github/Gitlab/Google/Ldap/Token-Auth
-* [guard get webhook-config](/docs/reference/guard_get_webhook-config.md)	 - Prints authentication token webhook config file
-
+- [guard](/docs/reference/guard.md) - Guard by AppsCode - Kubernetes Authentication WebHook Server
+- [guard get installer](/docs/reference/guard_get_installer.md) - Prints Kubernetes objects for deploying guard server
+- [guard get token](/docs/reference/guard_get_token.md) - Get tokens for Azure/Github/Gitlab/Google/Ldap/Token-Auth
+- [guard get webhook-config](/docs/reference/guard_get_webhook-config.md) - Prints authentication token webhook config file

--- a/docs/reference/guard_get_installer.md
+++ b/docs/reference/guard_get_installer.md
@@ -13,13 +13,13 @@ section_menu_id: reference
 
 Prints Kubernetes objects for deploying guard server
 
-```
+```console
 guard get installer [flags]
 ```
 
 ### Options
 
-```
+```text
       --addr string                                  Address (host:port) of guard server. (default "10.96.10.96:443")
       --auth-providers strings                       name of providers for which guard will provide authentication service (required), supported providers : Azure/Github/Gitlab/Google/Ldap/Token-Auth
       --authz-providers strings                      name of providers for which guard will provide authorization service, supported providers : Azure
@@ -85,5 +85,4 @@ guard get installer [flags]
 
 ### SEE ALSO
 
-* [guard get](/docs/reference/guard_get.md)	 - Get PKI
-
+- [guard get](/docs/reference/guard_get.md) - Get PKI

--- a/docs/reference/guard_get_token.md
+++ b/docs/reference/guard_get_token.md
@@ -13,13 +13,13 @@ section_menu_id: reference
 
 Get tokens for Azure/Github/Gitlab/Google/Ldap/Token-Auth
 
-```
+```console
 guard get token [flags]
 ```
 
 ### Options
 
-```
+```text
   -h, --help                      help for token
       --ldap.auth-choice int      LDAP user authentication mechanism, 0 for simple authentication, 1 for kerberos(via GSSAPI)
       --ldap.disable-pa-fx-fast   Disable PA-FX-Fast, Active Directory does not commonly support FAST negotiation so you will need to disable this on the client (default true)
@@ -33,5 +33,4 @@ guard get token [flags]
 
 ### SEE ALSO
 
-* [guard get](/docs/reference/guard_get.md)	 - Get PKI
-
+- [guard get](/docs/reference/guard_get.md) - Get PKI

--- a/docs/reference/guard_get_webhook-config.md
+++ b/docs/reference/guard_get_webhook-config.md
@@ -13,13 +13,13 @@ section_menu_id: reference
 
 Prints authentication token webhook config file
 
-```
+```console
 guard get webhook-config [flags]
 ```
 
 ### Options
 
-```
+```text
       --addr string           Address (host:port) of guard server. (default "10.96.10.96:443")
   -h, --help                  help for webhook-config
       --mode string           Mode to generate config, Supported mode: authn, authz (default "authn")
@@ -29,5 +29,4 @@ guard get webhook-config [flags]
 
 ### SEE ALSO
 
-* [guard get](/docs/reference/guard_get.md)	 - Get PKI
-
+- [guard get](/docs/reference/guard_get.md) - Get PKI

--- a/docs/reference/guard_init.md
+++ b/docs/reference/guard_init.md
@@ -15,14 +15,13 @@ Init PKI
 
 ### Options
 
-```
+```text
   -h, --help   help for init
 ```
 
 ### SEE ALSO
 
-* [guard](/docs/reference/guard.md)	 - Guard by AppsCode - Kubernetes Authentication WebHook Server
-* [guard init ca](/docs/reference/guard_init_ca.md)	 - Init CA
-* [guard init client](/docs/reference/guard_init_client.md)	 - Generate client certificate pair
-* [guard init server](/docs/reference/guard_init_server.md)	 - Generate server certificate pair
-
+- [guard](/docs/reference/guard.md) - Guard by AppsCode - Kubernetes Authentication WebHook Server
+- [guard init ca](/docs/reference/guard_init_ca.md) - Init CA
+- [guard init client](/docs/reference/guard_init_client.md) - Generate client certificate pair
+- [guard init server](/docs/reference/guard_init_server.md) - Generate server certificate pair

--- a/docs/reference/guard_init_ca.md
+++ b/docs/reference/guard_init_ca.md
@@ -13,18 +13,17 @@ section_menu_id: reference
 
 Init CA
 
-```
+```console
 guard init ca [flags]
 ```
 
 ### Options
 
-```
+```text
   -h, --help             help for ca
       --pki-dir string   Path to directory where pki files are stored. (default "/Users/tamal/.guard")
 ```
 
 ### SEE ALSO
 
-* [guard init](/docs/reference/guard_init.md)	 - Init PKI
-
+- [guard init](/docs/reference/guard_init.md) - Init PKI

--- a/docs/reference/guard_init_client.md
+++ b/docs/reference/guard_init_client.md
@@ -13,13 +13,13 @@ section_menu_id: reference
 
 Generate client certificate pair
 
-```
+```console
 guard init client [flags]
 ```
 
 ### Options
 
-```
+```text
   -h, --help                  help for client
   -o, --organization string   Name of Organization (Azure/Github/Gitlab/Google/Ldap/Token-Auth).
       --pki-dir string        Path to directory where pki files are stored. (default "/Users/tamal/.guard")
@@ -27,5 +27,4 @@ guard init client [flags]
 
 ### SEE ALSO
 
-* [guard init](/docs/reference/guard_init.md)	 - Init PKI
-
+- [guard init](/docs/reference/guard_init.md) - Init PKI

--- a/docs/reference/guard_init_server.md
+++ b/docs/reference/guard_init_server.md
@@ -13,13 +13,13 @@ section_menu_id: reference
 
 Generate server certificate pair
 
-```
+```console
 guard init server [flags]
 ```
 
 ### Options
 
-```
+```text
       --domains strings   Alternative Domain names
   -h, --help              help for server
       --ips ipSlice       Alternative IP addresses (default [127.0.0.1])
@@ -28,5 +28,4 @@ guard init server [flags]
 
 ### SEE ALSO
 
-* [guard init](/docs/reference/guard_init.md)	 - Init PKI
-
+- [guard init](/docs/reference/guard_init.md) - Init PKI

--- a/docs/reference/guard_login.md
+++ b/docs/reference/guard_login.md
@@ -15,15 +15,15 @@ Kubectl credential plugin
 
 ### Synopsis
 
-Kubectl credential plugin. Visit here for more info: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
+Kubectl credential plugin. Visit here for more info: <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins>
 
-```
+```console
 guard login [flags]
 ```
 
 ### Options
 
-```
+```text
   -k, --cluster string    Name of cluster
   -h, --help              help for login
   -p, --provider string   Name of cloud provider
@@ -31,5 +31,4 @@ guard login [flags]
 
 ### SEE ALSO
 
-* [guard](/docs/reference/guard.md)	 - Guard by AppsCode - Kubernetes Authentication WebHook Server
-
+- [guard](/docs/reference/guard.md) - Guard by AppsCode - Kubernetes Authentication WebHook Server

--- a/docs/reference/guard_run.md
+++ b/docs/reference/guard_run.md
@@ -13,13 +13,13 @@ section_menu_id: reference
 
 Run server
 
-```
+```console
 guard run [flags]
 ```
 
 ### Options
 
-```
+```text
       --auth-providers strings                       name of providers for which guard will provide authentication service (required), supported providers : Azure/Github/Gitlab/Google/Ldap/Token-Auth
       --authz-providers strings                      name of providers for which guard will provide authorization service, supported providers : Azure
       --azure.aks-authz-token-url string             url to call for AKS Authz flow
@@ -83,5 +83,4 @@ guard run [flags]
 
 ### SEE ALSO
 
-* [guard](/docs/reference/guard.md)	 - Guard by AppsCode - Kubernetes Authentication WebHook Server
-
+- [guard](/docs/reference/guard.md) - Guard by AppsCode - Kubernetes Authentication WebHook Server

--- a/docs/reference/guard_version.md
+++ b/docs/reference/guard_version.md
@@ -13,13 +13,13 @@ section_menu_id: reference
 
 Prints binary version number.
 
-```
+```console
 guard version [flags]
 ```
 
 ### Options
 
-```
+```text
       --check string   Check version constraint
   -h, --help           help for version
       --short          Print just the version number.
@@ -27,5 +27,4 @@ guard version [flags]
 
 ### SEE ALSO
 
-* [guard](/docs/reference/guard.md)	 - Guard by AppsCode - Kubernetes Authentication WebHook Server
-
+- [guard](/docs/reference/guard.md) - Guard by AppsCode - Kubernetes Authentication WebHook Server

--- a/docs/setup/developer-guide/overview.md
+++ b/docs/setup/developer-guide/overview.md
@@ -12,9 +12,10 @@ menu_name: product_guard_{{ .version }}
 section_menu_id: setup
 ---
 
-> New to Guard? Please start [here](/docs/concepts/README.md).
+> New to Guard? Please see the [Guard Concepts Guide](/docs/concepts).
 
 ## Development Guide
+
 This document is intended to be the canonical source of truth for things like supported toolchain versions for building Guard.
 If you find a requirement that this doc does not capture, please submit an issue on github.
 
@@ -22,10 +23,12 @@ This document is intended to be relative to the branch in which it is found. It 
 for the development branch, but release branches of Guard should not change.
 
 ### Build Guard
+
 Some of the Guard development helper scripts rely on a fairly up-to-date GNU tools environment, so most recent Linux distros should
 work just fine out-of-the-box.
 
 #### Setup GO
+
 Guard is written in Google's GO programming language. Currently, Guard is developed and tested on **go 1.8.3**. If you haven't set up a GO
 development environment, please follow [these instructions](https://golang.org/doc/code.html) to install GO.
 
@@ -37,6 +40,7 @@ $ cd $(go env GOPATH)/src/go.kubeguard.dev/guard
 ```
 
 #### Install Dev tools
+
 To install various dev tools for Guard, run the following command:
 
 ```console
@@ -52,6 +56,7 @@ $ guard version
 ```
 
 #### Dependency management
+
 Guard uses [Glide](https://github.com/Masterminds/glide) to manage dependencies. Dependencies are already checked in the `vendor` folder.
 If you want to update/add dependencies, run:
 
@@ -60,6 +65,7 @@ $ glide slow
 ```
 
 #### Build Docker images
+
 To build and push your custom Docker image, follow the steps below. To release a new version of Guard, please follow the [release guide](/docs/setup/developer-guide/release.md).
 
 ```console

--- a/docs/setup/install-kops.md
+++ b/docs/setup/install-kops.md
@@ -12,13 +12,14 @@ menu_name: product_guard_{{ .version }}
 section_menu_id: setup
 ---
 
-> New to Guard? Please start [here](/docs/concepts).
+> New to Guard? Please see the [Guard Concepts Guide](/docs/concepts).
 
 # Kops Installation Guide
 
-[Kops](https://github.com/kubernetes/kops) is a popular installer for production grade Kubernetes clusters. Please start [here](/docs/setup/install.md) to get an overview of installation steps. This document only shows distinctions during Kops setup of guard.
+[Kops](https://github.com/kubernetes/kops) is a popular installer for production grade Kubernetes clusters. Please see the [Installation Guide](/docs/setup/install.md) to get an overview of installation steps. This document only shows distinctions during Kops setup of guard.
 
 ## During Initialize PKI
+
 For creation of guard server config you need a free cluster ip. There is an easy trick which helps to find it in most cases: Just find out your nonMasqueradeCIDR through `kops edit cluster --name <cluster_name>` and then add x.x.10.96 to this range e.g. if it is 100.64.0.0 use 100.64.10.96.
 
 If this does not work for some unknown reason, you have to describe one of your kube-api-server pods in kube-system namespace and find out `service-cluster-ip-range`. In this range you can use any ip which is not already assigned. You can show all ips through this command:
@@ -32,9 +33,11 @@ guard init server --ips=100.64.10.96
 ```
 
 ## During Deploy Guard server
+
 Before you apply your guard config with `kubectl apply -f` verify installer.yaml (`spec/clusterIP: 100.64.10.96`) is filled with rigth ip address.
 
 ## During Configure Kubernetes API Server
+
 To configure your api server to use `--authentication-token-webhook-config-file` you need to edit
 your kops cluster spec: `kops edit cluster --name <cluster_name>`. There you add the following
 specifications:
@@ -60,4 +63,4 @@ or things do not work, ssh to this master node and verify kubernetes api server 
 If some requests are working, exchange the other master nodes. This keeps your cluster working all
 the time.
 
-This document only shows difference between kops setup and [here](/docs/setup/install.md).
+This document only shows difference between kops setup and the [installation guide](/docs/setup/install.md).

--- a/docs/setup/install-kubespray.md
+++ b/docs/setup/install-kubespray.md
@@ -12,7 +12,7 @@ menu_name: product_guard_{{ .version }}
 section_menu_id: setup
 ---
 
-> New to Guard? Please start [here](/docs/concepts).
+> New to Guard? Please see the [Guard Concepts Guide](/docs/concepts).
 
 # Kubespray Installation Guide
 
@@ -22,17 +22,16 @@ section_menu_id: setup
 - The document can be followed on a running cluster or before creating a new Kubernetes Cluster.
 - All files referenced in this documents are in [guard](https://github.com/appscode/kubespray/tree/guard) branch of [appscode/kubespray](https://github.com/appscode/kubespray) repository
 
-
 ## Before You Begin
 
 - [Guard](/docs/setup/install.md) installed on OS X or Linux
 - [GitHub](https://help.github.com/articles/creating-a-new-organization-from-scratch/) Acccount with an organization and team(s)
 - [GitHub Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with _public_repo_ and _read:org_ access
 
-
 ## Guard Setup
 
 ### Initialize PKI
+
 This command creates a self-signed certificate authority (CA) and a key.
 
 ```console
@@ -47,6 +46,7 @@ $ tree .guard/
 ```
 
 ### Initialize Guard Server
+
 To initialize a Guard server, you just need a free cluster IP. Choose an IP from the IP range while installing Kubernetes Cluster through Kubespray. This can be found in [k8s-cluster.yml](https://github.com/appscode/kubespray/blob/guard/inventory/group_vars/k8s-cluster.yml#L99). We have chosen IP `10.233.0.27` in this document.
 
 ```console
@@ -62,9 +62,10 @@ $ tree .guard/
 1 directory, 4 files
 ```
 
-It is possible to use guard server DNS address instead of a cluster IP. Please visit [here](/docs/setup/install.md#using-guard-service-name-instead-of-ip-in-authentication-webhook-config-file) to learn the steps and its implications.
+It is possible to use guard server DNS address instead of a cluster IP. Please see the [Using Guard Service Name instead of IP](/docs/setup/install.md#using-guard-service-name-instead-of-ip-in-authentication-webhook-config-file) section to learn the steps and its implications.
 
 ### Initialize Guard Clients
+
 Here, we are using GitHub as a Guard auth provider.
 
 ```console
@@ -82,11 +83,12 @@ $ tree .guard/
 ```
 
 ### Modifications in Kubespray Repository
+
 Clone the [Kubespray](https://github.com/kubernetes-incubator/kubespray) git repository or the already clones repository which you have used to install Kubernetes Cluster.
 
 > Note: All the following files and commands are relative to the root of the git repository. Hyperlinks are also used a lot to make things easier.
 
-* Enable Guard and optionally RBAC policies in [k8s-cluster.yml](https://github.com/appscode/kubespray/blob/guard/inventory/group_vars/k8s-cluster.yml#L21-26)
+- Enable Guard and optionally RBAC policies in [k8s-cluster.yml](https://github.com/appscode/kubespray/blob/guard/inventory/group_vars/k8s-cluster.yml#L21-26)
 
 ```console
 kube_guard: true
@@ -95,27 +97,27 @@ kube_guard_rbac_policies: false
 
 > Note: `kube_guard_rbac_policies` if set to `true` assumes that you have teams named `admins` and `developers` in your GitHub Organization. Feel free to edit the files to match your environment. GitHub users in `admins` group get full access to Kubernetes Cluster and users in `developers` get full access to only `default` namespace.
 
-* `kubernetes` Ansible role: Include Guard Auth Token File
+- `kubernetes` Ansible role: Include Guard Auth Token File
 
 ```console
 $ mkdir roles/kubernetes/master/files
 $ guard get webhook-config <your_github_org> -o github --addr=10.233.0.27:443 > roles/kubernetes/master/files/guard_auth_token_file
 ```
 
-* `kubernetes` Ansible role: Create `guard-file.yml`
+- `kubernetes` Ansible role: Create `guard-file.yml`
 
 ```console
 $ curl -sL https://raw.githubusercontent.com/appscode/kubespray/guard/roles/kubernetes/master/tasks/guard-file.yml > roles/kubernetes/master/tasks/guard-file.yml
 ```
 
-* `kubernetes` Ansible role: Import `guard-file.yml` as a task in [main.yml](https://github.com/appscode/kubespray/blob/guard/roles/kubernetes/master/tasks/main.yml#L18-L19)
+- `kubernetes` Ansible role: Import `guard-file.yml` as a task in [main.yml](https://github.com/appscode/kubespray/blob/guard/roles/kubernetes/master/tasks/main.yml#L18-L19)
 
 ```console
 - import_tasks: guard-file.yml
   when: kube_guard|default(false)
 ```
 
-* `kubernetes` Ansible role: Update Kube API Server Deployment [template](https://github.com/appscode/kubespray/blob/guard/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2#L61-L63) with Guard Auth Token
+- `kubernetes` Ansible role: Update Kube API Server Deployment [template](https://github.com/appscode/kubespray/blob/guard/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2#L61-L63) with Guard Auth Token
 
 ```console
 {% if kube_guard|default(false) %}
@@ -123,14 +125,15 @@ $ curl -sL https://raw.githubusercontent.com/appscode/kubespray/guard/roles/kube
 {% endif %}
 ```
 
-* `guard-auth-webook` Ansible Role: Add an ansible role to configure Guard
+- `guard-auth-webook` Ansible Role: Add an ansible role to configure Guard
 
 This role enables Guard server on Kubernetes Master nodes.
+
 ```console
 $ mkdir -pv roles/guard-auth-webook/{files,tasks}
 ```
 
-* `guard-auth-webook` Ansible Role: Copy all files and directories from [guard-auth-webook](https://github.com/appscode/kubespray/tree/guard/roles/guard-auth-webook) role
+- `guard-auth-webook` Ansible Role: Copy all files and directories from [guard-auth-webook](https://github.com/appscode/kubespray/tree/guard/roles/guard-auth-webook) role
 
 At the time of writing this document, the structure looks like this.
 
@@ -149,7 +152,7 @@ roles/guard-auth-webook
 2 directories, 6 files
 ```
 
-* `guard-auth-webook` Ansible Role: Create Guard Deployment File
+- `guard-auth-webook` Ansible Role: Create Guard Deployment File
 
 ```console
 $ guard get installer \
@@ -159,6 +162,7 @@ $ guard get installer \
 ```
 
 The generated file creates these Kubernetes _assets_ packaged in a yaml file
+
 - serviceaccount
 - clusterrole
 - clusterrolebinding
@@ -172,7 +176,7 @@ By default, Guard installer yamls will run it on master instances. Kubespray doe
 $ sed -i "s/node-role.kubernetes.io\/master: \"\"/app: guard/" roles/guard-auth-webook/files/guard-installer.yml
 ```
 
-* Add the new Ansible Role
+- Add the new Ansible Role
 
 Update [cluster.yml](https://github.com/appscode/kubespray/blob/guard/cluster.yml#L126-L128) with the `guard-auth-webook` role
 
@@ -189,6 +193,7 @@ $ ansible-playbook -i inventory/hosts cluster.yml
 ```
 
 ## Add a GitHub User
+
 Add a Github user which is in your organization.
 
 ```console
@@ -196,7 +201,8 @@ $ kubectl config set-credentials <github-user> --token=<your-github-token>
 ```
 
 ## Check if everything went as desired
-* When RBAC policies are disabled.
+
+- When RBAC policies are disabled.
 
 ```console
 $ kubectl get pods --user <github-user>
@@ -205,7 +211,7 @@ Error from server (Forbidden): pods is forbidden: User "<github-user>" cannot li
 
 The `Forbidden` message here is a good sign, this means you have been authenticated but you do not have proper authorization. Now, you can start creating [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) policies.
 
-* When RBAC policies are enabled (your output may slightly vary)
+- When RBAC policies are enabled (your output may slightly vary)
 
 ```console
 $ kubectl --user <github-user> get nodes
@@ -217,7 +223,9 @@ kubernetes-worker1      Ready     node      1d        v1.9.5
 ```
 
 ## Troubleshooting
+
 ### Ensure guard file is present in Kubernetes API Server
+
 ```console
 $ kubectl -n kube-system exec -it kube-apiserver-kubernetes-lab-master0 -- ls /etc/kubernetes/tokens/guard
 /etc/kubernetes/tokens/guard
@@ -228,11 +236,13 @@ $ grep authentication-token-webhook-config-file /etc/kubernetes/manifests/kube-a
 ```
 
 ### Check Logs of API Server
+
 ```console
 $ kubectl -n kube-system logs kube-apiserver-kubernetes-lab-master0
 ```
 
 ## Support
+
 We use Slack for public discussions. To chit chat with us or the rest of the community, join us in the [AppsCode Slack team](https://appscode.slack.com/messages/C8M8HANQ0/details/) channel `#guard`. To sign up, use our [Slack inviter](https://slack.appscode.com/).
 
 If you have found a bug with Guard or want to request for new features, please [file an issue](https://go.kubeguard.dev/guard/issues/new).

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -12,18 +12,18 @@ menu_name: product_guard_{{ .version }}
 section_menu_id: setup
 ---
 
-> New to Guard? Please start [here](/docs/concepts).
+> New to Guard? Please see the [Guard Concepts Guide](/docs/concepts).
 
 # Installation Guide
 
 Guard binary works as a cli and server. In cli mode, you can use `guard` to generate various configuration to easily deploy Guard server. Guard server uses TLS client auth to secure the communication channel between Kubernetes api server and Guard server. You can run Guard server external to a Kubernetes cluster. This document shows you how to `self-host` Guard server in a Kubernetes cluster. To that end, we run Guard server using a predefined Service ClusterIP `10.96.10.96` and port `443`. This ClusterIP is chosen so that it falls in the default --service-cidr range for [Kubeadm](https://kubernetes.io/docs/admin/kubeadm/). If the service CIDR range for your cluster is different, please pick an appropriate ClusterIP.
 
-If you want to set up guard via [__Kops__](https://github.com/kubernetes/kops) visit [here](/docs/setup/install-kops.md) to see differences in setup.
+If you want to set up guard via [__Kops__](https://github.com/kubernetes/kops), see the [Kops installation guide](/docs/setup/install-kops.md) for differences in setup.
 
-If you want to set up guard via [__Kubespray__](https://github.com/kubernetes-incubator/kubespray) visit [here](/docs/setup/install-kubespray.md).
-
+If you want to set up guard via [__Kubespray__](https://github.com/kubernetes-incubator/kubespray), see the [Kubespray installation guide](/docs/setup/install-kubespray.md).
 
 ## Install Guard as CLI
+
 Download pre-built binaries from [appscode/guard Github releases](https://go.kubeguard.dev/guard/releases) and put the binary to some directory in your `PATH`. To install on Linux 64-bit and MacOS 64-bit you can run the following commands:
 
 ```console
@@ -38,13 +38,13 @@ wget -O guard https://go.kubeguard.dev/guard/releases/download/{{< param "info.v
   && sudo mv guard /usr/local/bin/
 ```
 
-If you prefer to install Guard cli from source code, you will need to set up a GO development environment following [these instructions](https://golang.org/doc/code.html). Then, install `guard` CLI using `go get` from source code.
+If you prefer to install Guard cli from source code, you will need to set up a `go` development environment following [these instructions](https://golang.org/doc/code.html). Then, install `guard` CLI using `go install` from source code.
 
 ```bash
-go get go.kubeguard.dev/guard
+go install go.kubeguard.dev/guard@latest
 ```
 
-Please note that this will install Guard cli from master branch which might include breaking and/or undocumented changes.
+Please note that this will install Guard CLI from the master branch which might include breaking and/or undocumented changes.
 
 ## Initialize PKI
 
@@ -124,6 +124,7 @@ Wrote ca certificates in  /tmp/guard/pki
 Guard can use [supported authenticator](/docs/guides/) to authenticate users for a Kubernetes cluster. A Kubernetes cluster can use one of these organization to authenticate users. But you can configure a single Guard server to perform authentication for multiple clusters, where each cluster uses a different auth provider.
 
 ## Deploy Guard server
+
 Now deploy Guard server so that your Kubernetes api server can access it. Use the command below to generate YAMLs for your particular setup. Then use `kubectl apply -f` to install Guard server.
 
 ```console
@@ -139,6 +140,7 @@ By default, the installer.yaml will deploy Guard server on master instances. If 
 the node selector in installer.yaml to `"node-role.kubernetes.io/master": "true"` due to [kubernetes-incubator/kubespray#2108](https://github.com/kubernetes-incubator/kubespray/issues/2108).
 
 ## Configure Kubernetes API Server
+
 To use webhook authentication, you need to set `--authentication-token-webhook-config-file` flag of your Kubernetes api server to a [kubeconfig file](https://kubernetes.io/docs/admin/authentication/#webhook-token-authentication) describing how to access the Guard webhook service. You can use the following command to generate a sample `kubeconfig` file.
 
 ```console
@@ -165,7 +167,6 @@ users:
     client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMyakNDQWNLZ0F3SUJBZ0lJQTZJZmR0dEIzTlV3RFFZSktvWklodmNOQVFFTEJRQXdEVEVMTUFrR0ExVUUKQXhNQ1kyRXdIaGNOTVRjd09ESTVNVFF5TXpNNFdoY05NVGd3T0RJNU1UUXlOREEwV2pBa01ROHdEUVlEVlFRSwpFd1pIYVhSb2RXSXhFVEFQQmdOVkJBTVRDR0Z3Y0hOamIyUmxNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DCkFROEFNSUlCQ2dLQ0FRRUE3NG5nc25IcldkeHovZUNWdEVwVUdVcmQ1dWkwSVhteGFkZlVuM3hpVTduZHdsYzgKc2loT1hLQ2pEaWM5cjZweW16MTJ5Ry93WCtZM1diOUU5a0VxQzg5L2oyR0ZrSFNVOU40VFlsQlZka0pSRUQ2dAoySjZpVnNPZE9BeE9MeDNidG5QR3RYNi9KRTZSTVFCLzhkcUYyenFUZm5ST3FFNFE0N01wL0NKYmdkcEpjbm9mCmdKVzN5Z2pJYk96WHhIZVNNcjlIclhveGRLbGFPVk1hU3BmY0RVREZrQXV1MEREZCszT3hwbG03TlNpS2JpbnUKM0d3VDc4YkRtNzZCTCtEOWhKeXB2OVZDTFkyMVB3WnB3ejJmaThYdzN2WDM3VVdPenA0OXlCMyttYnVjWkpGSgpCRTNORVJyZFVvWFhyeUJrdDhEdXp0SzhYM3dhOExGdmsvOWxWd0lEQVFBQm95Y3dKVEFPQmdOVkhROEJBZjhFCkJBTUNCYUF3RXdZRFZSMGxCQXd3Q2dZSUt3WUJCUVVIQXdJd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFFN0YKZkdpOWpDSzc0eGZZdmY3b3Byb1NxSVpoYmdyODVkcENCZ2FVbEhlK0ZJYkpVeWhnL2c2OVNCOUlhWitpTWYxNgpNWkJVTWs4Tmg5dUZWYWVQVUdCWG0vTUtBeGx0V0J0UHh0VFFMV0cycU9LbXczK3Z5UUJ4R2JMaytycndXVS9YCjR5SzcxbWc5ZG5GVXdWOGI2UWtwM1IxMVdCZzlCeHExU1RQL210S2NyNVVDS3ZWVmlEYlpobzRkRy9ZUHdMbEUKS1N4UGtqS3NPVU54dDlHZkdNTHVRMVFQWXZDYTZjZ1MxN3BERWZacWVqdmthc0UxeTNSQWpPa2pubTJ2KzIzbgpBN2kxYWwwMDZjTEpQdTl3S3IyMzhJQ0Q3N2ZxQzhTaXJhN3V3NUgxbkVvMTh1am94NmI2UG5XazdmeTZabDRHCjBWMXBCSDJtL1JqK0RudGVTM0k9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
     client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcFFJQkFBS0NBUUVBNzRuZ3NuSHJXZHh6L2VDVnRFcFVHVXJkNXVpMElYbXhhZGZVbjN4aVU3bmR3bGM4CnNpaE9YS0NqRGljOXI2cHltejEyeUcvd1grWTNXYjlFOWtFcUM4OS9qMkdGa0hTVTlONFRZbEJWZGtKUkVENnQKMko2aVZzT2RPQXhPTHgzYnRuUEd0WDYvSkU2Uk1RQi84ZHFGMnpxVGZuUk9xRTRRNDdNcC9DSmJnZHBKY25vZgpnSlczeWdqSWJPelh4SGVTTXI5SHJYb3hkS2xhT1ZNYVNwZmNEVURGa0F1dTBERGQrM094cGxtN05TaUtiaW51CjNHd1Q3OGJEbTc2QkwrRDloSnlwdjlWQ0xZMjFQd1pwd3oyZmk4WHczdlgzN1VXT3pwNDl5QjMrbWJ1Y1pKRkoKQkUzTkVScmRVb1hYcnlCa3Q4RHV6dEs4WDN3YThMRnZrLzlsVndJREFRQUJBb0lCQVFDam9LdTlPZFJyTGd5TwpBRHhEVEFMbXhCMlEvcVVOdVBOWU9mY2tldk12L21kZHVmbmNPV3hPR2UxSVhjWGxtYWx3SWl4aC94VlViUTZpClgrWGIwZWZHNlpkWmVtU2lxUUNYeEp1NUxPYzBRVmplbi9KaFp2dStDU0g4aDJ0aEJDUnlIZVEvVnJWN043QTIKcVFDOVZXamF1TWpJT09zQ1RWRjhPWWNVbE9PdGJ2MFFRSUFNRDdxak1jcTdIRlJMbjlHSXJjSGVZWTd2RTdONQpucFdOMWZOT25BZXNnaVNRcGYxdGNYcmJUckNkb1JweExlU2RFUngyVnBkdFE1V3hFTm9YYURJT3FJVXB2anJaCjIwSUZqazY3eVVOTlBCLzJkU3VmZzVaekxEYWNGUy9lenYvUDVJYnVEazBHZWQyZGhkT2t3K2duVFNabjg0Sk4KMDg4TlMvVUJBb0dCQVBGOG44dEVmTURDNjlTc1RGWWh4NUc2aE1PWThlS0kxTDJQeTVVaEN4WCtXUlpoQndaVQpWaGhVMVpOcTgvUXkwb201WEQyT1UwR0tGQjY3aE9kU1l6TUc3a0NqKzl3bHZDM0loRmxLd2R1ZC8relBWTFkvCngxRjFtVnA3aTllZXZiZmdZdUQxdDRvTDVxc2lveldGZ2g2UndSZzVWTXpGd0N2WXZwUk9CcGZUQW9HQkFQM3YKUjNyRit1cW96YU9IcldrUjFEL3E5MHlRd3ZpamlRWDhyNEg3QVZTVVpnQmhwbEpmUDRTVU84NWdUbmhBLzl4ZQp3R1NTQzFGWkpVeDRmOW41MFN0dFlkNFhIMTZiU1lyOEpWQWxVRWY5QWR1czBkc1pKdkZLSEM5S3VjNEFPeUFPClYvUGR0Rk1FV2J5WERSQXdBTTVwNzZsU1pZVXA5cDFLVTZ6SndHM3RBb0dCQUlmdzdRK0RmV3NTRDZwSVdDekEKbFZUL0Y4LzRZR3B6TnJlRHBFcE9NS3h2NDN6S29DYTdBVUJ2T1Uva2pISnl6YnlFSVYzeHFnS2lGVk43b29TSwpCNWZwRmVSRHEvdXhMbTdqaTBXczVOYVo2a0ZJTWRycXFteTc4OWxRNVZjN1lIZUxsSDRwTk9vOGF0ejZBY0NXCmFMcUd1Sm5IWkdwbUJCbHF5Vlk1V2xMTEFvR0FPWVlBelVFWURCeGRLUlJOSmlZUnpNRHZjSHJDa0F5THQ3MTgKREpmTnYxazJtaE9FMTlnWHpYSys4WXREZTE1T0Y1K25PYUVUeTBQRWZVUTJ3aXdqUkJFdFFHQkFqTy9rZ3dXSApkbFpkajFFeklJNVBvN0JZOEFQM3lvYkUvSE4wOFZnT2VJSGFuWXU0d0UzL2VaRkdQWHdsL0ZkY0JBUnpoMElWCkhtazluQ2tDZ1lFQXJyNGQ3WFBUNlBvTTA5TjFSYnVtQnROUW96cGxpb0wwb0tqZUxHL0RHcUd5Q3lpcDVsNnMKUW5vblpPcW9BVzdqZlRiMThvVVVzVkJTdDJvd20zempac05XZFdZcEptL1ZCSDQvY0dOeFJuSXN1OFNsdFdBZAp1YjVZQS9YcnEvUTRNcUJnZEVwYm9HTnlzUVlscE0rMmxHZWpiZ0pDUTI4b3dJYndLQ3JSY2t3PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
 ```
-
 
 ## Using Guard service name instead of IP in authentication webhook config file
 

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -11,7 +11,7 @@ menu_name: product_guard_{{ .version }}
 section_menu_id: setup
 ---
 
-> New to Guard? Please start [here](/docs/concepts).
+> New to Guard? Please see the [Guard Concepts Guide](/docs/concepts).
 
 ## Troubleshooting
 
@@ -19,7 +19,7 @@ section_menu_id: setup
 
 Say, you are seeing logs like below in Guard server logs:
 
-```
+```text
 I0830 16:41:59.919947       1 logs.go:19] FLAG: --alsologtostderr="false"
 I0830 16:41:59.919987       1 logs.go:19] FLAG: --analytics="true"
 I0830 16:41:59.920016       1 logs.go:19] FLAG: --ca-cert-file="/srv/guard/pki/ca.crt"
@@ -38,7 +38,7 @@ I0830 16:42:45.430823       1 logs.go:19] http: TLS handshake error from 1.1.2.6
 I0830 16:43:00.483658       1 logs.go:19] http: TLS handshake error from 1.1.2.6:34062: remote error: tls: bad certificate
 ```
 
-```
+```text
 admin@ip-172-20-48-207:~$ sudo tail -f /var/log/kube-apiserver.log | grep auth
 E0830 16:56:46.430468       6 authentication.go:58] Unable to authenticate the request due to an error: [invalid bearer token, [invalid bearer token, [invalid bearer token, invalid bearer token, Post https://10.7.3.3:9844/apis/authentication.k8s.io/v1beta1/tokenreviews: x509: certificate is valid for 1.27.55.255, not 10.7.3.3]]]
 ```
@@ -49,7 +49,7 @@ To debug this issue, follow the steps below:
 
 2. Now check the common name(CN) and subject alternative names (SANS) in the server.crt. If that does not include the ip addressfrom step 1, we need to regenerate the server certificates.
 
-```
+```console
 $ guard init server --ips=<ip1>,<ip2> --domains=<dns1>,<dns2>
 ```
 

--- a/docs/setup/uninstall.md
+++ b/docs/setup/uninstall.md
@@ -13,6 +13,7 @@ section_menu_id: setup
 ---
 
 # Uninstall Guard
+
 Please follow the steps below to uninstall Guard:
 
 - Delete the various objects created for Guard operator.


### PR DESCRIPTION
This PR fixes many spacing and formatting inconsistencies across the docs. Also fixes links on the main `README.md`. This mostly conforms to `markdownlint`, since I have that plugin enabled in my VSCode and just fixed most of the items it called out. This increases consistency in the formatting of the documentation.