### PR TITLE
fix: return denied instead of 500 for wildcard SAR with empty operations map

### DIFF
--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -311,7 +311,10 @@ func getDataActions(ctx context.Context, subRevReq *authzv1.SubjectAccessReviewS
 
 		} else {
 			if len(storedOperationsMap) == 0 {
-				return nil, fmt.Errorf("Wildcard support for Resource/Verb/Group is not enabled for request Group: %s, Resource: %s, Verb: %s", subRevReq.ResourceAttributes.Group, subRevReq.ResourceAttributes.Resource, subRevReq.ResourceAttributes.Verb)
+				return nil, errutils.WithCode(
+					fmt.Errorf("wildcard resource/verb/group check unavailable: operations map not populated (Group: %s, Resource: %s, Verb: %s)",
+						subRevReq.ResourceAttributes.Group, subRevReq.ResourceAttributes.Resource, subRevReq.ResourceAttributes.Verb),
+					http.StatusBadRequest)
 			}
 
 			authInfoList, err = getAuthInfoListForWildcard(ctx, subRevReq, storedOperationsMap, clusterType, isCustomerResourceTypeCheckAvailable, allowSubresourceTypeCheck)

--- a/authz/providers/azure/rbac/checkaccessreqhelper_test.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper_test.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
 	"testing"
 
 	azureutils "go.kubeguard.dev/guard/util/azure"
+	errutils "go.kubeguard.dev/guard/util/error"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -686,6 +688,62 @@ func Test_getDataActions(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func Test_getDataActions_wildcardWithEmptyOperationsMap(t *testing.T) {
+	getStoredOperationsMap = func() azureutils.OperationsMap {
+		return azureutils.NewOperationsMap()
+	}
+
+	tests := []struct {
+		name string
+		spec *authzv1.SubjectAccessReviewSpec
+	}{
+		{
+			name: "wildcard resource",
+			spec: &authzv1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Verb:      "create",
+					Namespace: "kube-system",
+					Resource:  "*",
+				},
+			},
+		},
+		{
+			name: "wildcard verb",
+			spec: &authzv1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Verb:     "*",
+					Resource: "pods",
+				},
+			},
+		},
+		{
+			name: "wildcard group",
+			spec: &authzv1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Verb:     "get",
+					Resource: "pods",
+					Group:    "*",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			got, err := getDataActions(ctx, tt.spec, "Microsoft.ContainerService/managedClusters", false, false)
+
+			assert.Nil(t, got, "expected nil actions for wildcard with empty operations map")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "operations map not populated")
+
+			var codeErr errutils.HttpStatusCode
+			assert.True(t, errors.As(err, &codeErr), "error should implement HttpStatusCode")
+			assert.Equal(t, http.StatusBadRequest, codeErr.Code(), "error should carry 400 status code")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- When a `SelfSubjectAccessReview` contains wildcard `resource: "*"` (or `verb: "*"`, `group: "*"`) and the operations map is not populated, Guard returned a plain `fmt.Errorf` with no HTTP status code attached
- This defaulted to HTTP 500 in `azure.go`, causing the API server to **retry the request** (amplifying volume) and **preventing the result from being cached**
- The error is deterministic - it will never resolve on retry because the operations map is populated once at startup

The fix wraps the error with `errutils.WithCode(..., http.StatusBadRequest)` so the existing 4xx-to-denied logic in `azure.go:217` converts it into a denied response (`allowed: false, denied: true`) returned as HTTP 200 to the API server. This stops retry amplification and makes the result cacheable.

### Before

```
API server -> Guard -> 500 (retry) -> Guard -> 500 (retry) -> Guard -> 500 ...
```

### After

```
API server -> Guard -> 200 {allowed: false, denied: true} (cached, no retries)
```

## Context

Reported by Bench Wang investigating a CRI with ~5s API server latency. Audit logs showed repeated `SelfSubjectAccessReview` requests with `resource: "*"` from a single AAD user. Guard logs confirmed the 500 error on every attempt:

```
E0520 06:32:12.192317  1 utils.go:130] Authorization check failed (requestID: ..., statusCode: 500):
  error in preparing check access request: Error while creating list of dataactions for check access call:
  Wildcard support for Resource/Verb/Group is not enabled for request Group: , Resource: *, Verb: create
```

The latency was caused by the API server retrying the 500 responses.

## Test plan

- [x] Unit tests for all three wildcard variants (resource, verb, group) verify the error carries `http.StatusBadRequest` and the `HttpStatusCode` interface
- [x] `go build ./...` passes
- [x] Existing test suite unaffected (pre-existing `Test_prepareCheckAccessRequestBodyWithCustomResource` failure is on master)