### PR TITLE
feat: add inference action for azure rbac

### DIFF
--- a/authz/providers/azure/rbac/checkaccessreqhelper.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper.go
@@ -226,6 +226,8 @@ func getActionName(verb string) string {
 		return "use/action"
 	case "impersonate":
 		return "impersonate/action"
+	case "inference":
+		return "inference/action"
 
 	case "create":
 		fallthrough // instead of action create will be mapped to write

--- a/authz/providers/azure/rbac/checkaccessreqhelper_test.go
+++ b/authz/providers/azure/rbac/checkaccessreqhelper_test.go
@@ -306,6 +306,17 @@ func Test_getDataActions(t *testing.T) {
 		},
 
 		{
+			"aimanager-inference",
+			args{
+				isWildcardTest: false,
+				subRevReq: &authzv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authzv1.ResourceAttributes{Group: "", Resource: "namespaces", Version: "v1", Name: "test", Verb: "inference"},
+				}, clusterType: "Microsoft.ContainerService/aiManagers",
+			},
+			[]azureutils.AuthorizationActionInfo{{AuthorizationEntity: azureutils.AuthorizationEntity{Id: "Microsoft.ContainerService/aiManagers/namespaces/inference/action"}, IsDataAction: true}},
+		},
+
+		{
 			"arc5",
 			args{
 				isWildcardTest: false,


### PR DESCRIPTION
Add inference action for Azure RBAC provider for AI Manager. This new verb will be used to authorize inference requests for AI Manager clusters.

The changes are:
1. Support inference verb
2. Add unit test for new verb