### PR TITLE
google: make accepted OAuth2 client ID configurable via --google.client-id

### DIFF
--- a/auth/providers/google/google.go
+++ b/auth/providers/google/google.go
@@ -65,8 +65,12 @@ func New(ctx context.Context, opts Options, domain string) (auth.Interface, erro
 		return nil, errors.Wrap(err, "failed to create oidc provider for google")
 	}
 
+	clientID := opts.ClientID
+	if clientID == "" {
+		clientID = GoogleOauth2ClientID
+	}
 	g.verifier = provider.Verifier(&oidc.Config{
-		ClientID: GoogleOauth2ClientID,
+		ClientID: clientID,
 	})
 
 	if opts.ServiceAccountJsonFile != "" {

--- a/auth/providers/google/options.go
+++ b/auth/providers/google/options.go
@@ -35,11 +35,14 @@ import (
 type Options struct {
 	ServiceAccountJsonFile string
 	AdminEmail             string
+	ClientID               string
 	jwtConfig              *jwt.Config
 }
 
 func NewOptions() Options {
-	return Options{}
+	return Options{
+		ClientID: GoogleOauth2ClientID,
+	}
 }
 
 func (o *Options) Configure() error {
@@ -66,6 +69,7 @@ func (o *Options) Configure() error {
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ServiceAccountJsonFile, "google.sa-json-file", o.ServiceAccountJsonFile, "Path to Google service account json file")
 	fs.StringVar(&o.AdminEmail, "google.admin-email", o.AdminEmail, "Email of G Suite administrator")
+	fs.StringVar(&o.ClientID, "google.client-id", o.ClientID, "OAuth2 client ID whose ID tokens are accepted (audience check). Defaults to Guard's own client ID used by `guard get token -o google`")
 }
 
 func (o *Options) Validate() []error {
@@ -124,6 +128,9 @@ func (o Options) Apply(d *apps.Deployment) (extraObjs []runtime.Object, err erro
 	}
 	if o.AdminEmail != "" {
 		args = append(args, fmt.Sprintf("--google.admin-email=%s", o.AdminEmail))
+	}
+	if o.ClientID != "" && o.ClientID != GoogleOauth2ClientID {
+		args = append(args, fmt.Sprintf("--google.client-id=%s", o.ClientID))
 	}
 
 	container.Args = args


### PR DESCRIPTION
## Motivation

The Google authenticator pins the ID-token audience to Guard's own installed-app OAuth client (`GoogleOauth2ClientID`). That's the right default for tokens minted by `guard get token -o google`, but deployments that issue kubeconfig tokens through their **own** OAuth client (e.g. a web-based login helper that runs the OAuth flow server-side and hands users a kubeconfig) can't use the Google webhook at all, every TokenReview fails with:

```bash
oidc: expected audience "37154062056-...apps.googleusercontent.com" got ["<deployment's client id>"]
```

## Change

- Add `--google.client-id` to override the audience the verifier accepts. Defaults to the existing built-in client ID, so current setups are unaffected.
- `guard get installer` passes the flag through when a non-default value is set.
- The audience check itself is unchanged, a specific client ID is still always enforced.

Tested against a live cluster: with `--google.client-id` set to our own OAuth client, TokenReview authenticates our tokens and returns Directory groups; tokens for any other audience are still rejected, as are same-audience tokens from identities outside the hosted domain.

We're running this in production against v0.16.29 on two kubeadm clusters.